### PR TITLE
Update Javadoc headings for CLI classes

### DIFF
--- a/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/AetherCli.java
+++ b/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/AetherCli.java
@@ -82,14 +82,14 @@ public class AetherCli implements Callable<Integer> {
      * root {@link AetherCli} command and executes it with the provided arguments.
      * The process exit code is set based on the command execution result.</p>
      *
-     * <h3>Exit Codes</h3>
+     * <h4>Exit Codes</h4>
      * <ul>
      *   <li>{@code 0} - Success (or help displayed)</li>
      *   <li>{@code 1} - Error occurred during command execution</li>
      *   <li>{@code 2} - Validation found files needing migration (validate command only)</li>
      * </ul>
      *
-     * <h3>Configuration</h3>
+     * <h4>Configuration</h4>
      * <p>The CommandLine instance is configured with:</p>
      * <ul>
      *   <li>Case-insensitive enum value parsing enabled</li>

--- a/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/bootstrap/BootstrapLoader.java
+++ b/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/bootstrap/BootstrapLoader.java
@@ -89,7 +89,7 @@ public final class BootstrapLoader {
      *   <li>Must be accessible on the current thread's context class loader</li>
      * </ul>
      *
-     * <h3>Error Handling</h3>
+     * <h4>Error Handling</h4>
      * <p>All reflection-related exceptions are wrapped in {@link BootstrapLoadException}
      * with descriptive error messages to aid debugging:</p>
      * <ul>
@@ -148,7 +148,7 @@ public final class BootstrapLoader {
      * as the iterator is consumed. Each call to this method creates a fresh
      * ServiceLoader instance.</p>
      *
-     * <h3>Registration</h3>
+     * <h4>Registration</h4>
      * <p>To register a bootstrap for discovery, create a file at:</p>
      * <pre>
      * src/main/resources/META-INF/services/de.splatgames.aether.datafixers.api.bootstrap.DataFixerBootstrap

--- a/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/util/VersionExtractor.java
+++ b/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/util/VersionExtractor.java
@@ -88,7 +88,7 @@ public final class VersionExtractor {
      * and extracts the integer version value. The field path supports dot notation
      * for accessing nested fields.</p>
      *
-     * <h3>Algorithm</h3>
+     * <h4>Algorithm</h4>
      * <ol>
      *   <li>Validates the field path syntax</li>
      *   <li>Wraps the raw data in a {@link Dynamic}</li>
@@ -97,14 +97,14 @@ public final class VersionExtractor {
      *   <li>Wraps the integer in a {@link DataVersion}</li>
      * </ol>
      *
-     * <h3>Valid Field Paths</h3>
+     * <h4>Valid Field Paths</h4>
      * <ul>
      *   <li>{@code "version"} - Single field</li>
      *   <li>{@code "meta.version"} - Nested field</li>
      *   <li>{@code "a.b.c.version"} - Deeply nested field</li>
      * </ul>
      *
-     * <h3>Invalid Field Paths</h3>
+     * <h4>Invalid Field Paths</h4>
      * <ul>
      *   <li>{@code ""} - Empty</li>
      *   <li>{@code ".version"} - Leading dot</li>


### PR DESCRIPTION
This pull request updates Javadoc headings for CLI classes, changing them from `<h3>` to `<h4>` to ensure consistency across the documentation.