### PR TITLE
Update parent POM versions to `0.4.0-SNAPSHOT`

### DIFF
--- a/aether-datafixers-api/pom.xml
+++ b/aether-datafixers-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-api</artifactId>

--- a/aether-datafixers-bom/pom.xml
+++ b/aether-datafixers-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-bom</artifactId>

--- a/aether-datafixers-cli/pom.xml
+++ b/aether-datafixers-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-cli</artifactId>

--- a/aether-datafixers-codec/pom.xml
+++ b/aether-datafixers-codec/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-codec</artifactId>

--- a/aether-datafixers-core/pom.xml
+++ b/aether-datafixers-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-core</artifactId>

--- a/aether-datafixers-examples/pom.xml
+++ b/aether-datafixers-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-examples</artifactId>

--- a/aether-datafixers-schema-tools/pom.xml
+++ b/aether-datafixers-schema-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-schema-tools</artifactId>

--- a/aether-datafixers-testkit/pom.xml
+++ b/aether-datafixers-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-testkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.splatgames.aether.datafixers</groupId>
     <artifactId>aether-datafixers</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>aether-datafixers-api</module>


### PR DESCRIPTION
Updated the parent POM version to `0.4.0-SNAPSHOT` for all modules to ensure compatibility with the latest changes. No functional changes were introduced with this update.