### PR TITLE
Add GitHub issue and discussion templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @aether-framework/maintainers
+
+/.github/workflows/ @aether-framework/maintainers

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,52 @@
+title: "Idea / RFC"
+labels: ["enhancement", "discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to propose new features or API changes before opening a PR.
+        The more concrete the use-case, the better.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / Problem
+      placeholder: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      placeholder: Describe the proposed behavior and how users would use it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: api
+    attributes:
+      label: API / Design Sketch (optional)
+      description: If you have a rough idea of the public API, put it here.
+      render: java
+    validations:
+      required: false
+
+  - type: textarea
+    id: breaking
+    attributes:
+      label: Breaking Changes / Migration
+      description: Would this be breaking? If yes, what would migration look like?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority (estimate)
+      options:
+        - low
+        - medium
+        - high
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,59 @@
+title: "Q&A / Help"
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for usage questions and help requests.
+        For reproducible bugs, please open an Issue instead.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version are you using?
+      placeholder: e.g. 0.5.0 (or main @ <commit>)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Module
+      options:
+        - api
+        - core
+        - codec
+        - testkit
+        - cli
+        - schema-tools
+        - spring-boot-starter
+        - other / unknown
+    validations:
+      required: false
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What are you trying to accomplish?
+      placeholder: Be specific about the desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_tried
+    attributes:
+      label: What did you try?
+      description: Include minimal code/config and what happened.
+      render: java
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Anything else that helps (stacktraces, links, constraints).
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,40 @@
+title: "Show & Tell"
+labels: ["community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Show what you built with this project!
+        Share links, screenshots, benchmarks, or lessons learned.
+
+  - type: input
+    id: project
+    attributes:
+      label: Project name
+      placeholder: e.g. MyGameSaveMigrator
+    validations:
+      required: true
+
+  - type: input
+    id: link
+    attributes:
+      label: Link (optional)
+      placeholder: Repository / website / blog post
+    validations:
+      required: false
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What did you build?
+      placeholder: Describe the project and how this library is used.
+    validations:
+      required: true
+
+  - type: textarea
+    id: learnings
+    attributes:
+      label: Learnings / Feedback
+      description: What worked well? What should be improved?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,131 @@
+name: 🐞 Bug Report
+description: Report a reproducible bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Please provide enough details so we can reproduce and fix the issue quickly.
+
+  - type: input
+    id: affected_version
+    attributes:
+      label: Affected Version
+      description: Which version(s) are affected?
+      placeholder: e.g. 0.5.0 (or main @ <commit>)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_module
+    attributes:
+      label: Affected Module
+      description: Which module is affected?
+      options:
+        - api
+        - core
+        - codec
+        - testkit
+        - cli
+        - schema-tools
+        - spring-boot-starter
+        - other / unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short summary of what is wrong.
+      placeholder: One or two sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a minimal, complete, reproducible set of steps.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: minimal_example
+    attributes:
+      label: Minimal Reproducible Example (code/config)
+      description: If possible, paste a small snippet that reproduces the issue.
+      render: java
+    validations:
+      required: false
+
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Logs / Stacktrace
+      description: Paste relevant logs or the full stacktrace.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression?
+      description: Did this work in a previous version?
+      options:
+        - "unknown"
+        - "yes"
+        - "no"
+    validations:
+      required: true
+
+  - type: input
+    id: last_working_version
+    attributes:
+      label: Last Known Working Version (if regression)
+      placeholder: e.g. 0.4.0
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Java version, OS, build tool, etc.
+      placeholder: e.g. Java 21, Maven 3.9.x, Windows 11 / Ubuntu 24.04
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues to avoid duplicates.
+          required: true
+        - label: I can reproduce this reliably.
+          required: false
+        - label: I included a minimal example or clear repro steps.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Security Policy
+    url: https://github.com/aether-framework/aether-datafixers/security/policy
+    about: Please report serious vulnerabilities via the security policy / advisories.
+  - name: 📖 Documentation
+    url: https://github.com/aether-framework/aether-datafixers
+    about: Check the README and docs first.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,53 @@
+name: 📚 Documentation
+description: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Where is the docs issue? (URL, file path, section)
+      placeholder: e.g. docs/codec.md#json or README.md#usage
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options:
+        - typo / wording
+        - unclear explanation
+        - missing section
+        - incorrect/outdated information
+        - broken link
+        - example does not work
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Content / Problem
+      description: What exactly is wrong right now?
+      placeholder: Paste the relevant snippet or describe the issue precisely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Suggested Change
+      description: What should it say/do instead?
+      placeholder: Proposed wording, fixed link, corrected example, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (optional)
+      description: Why is it confusing? Who is the target audience?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,93 @@
+name: ✨ Feature Request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the problem first, then the proposed solution.
+        Good feature requests include use-cases, constraints, and API impact.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What are you trying to achieve? What is painful today?
+      placeholder: Describe the user story and why it matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you want to see.
+      placeholder: Describe expected behavior and how it should be used.
+    validations:
+      required: true
+
+  - type: textarea
+    id: api_design
+    attributes:
+      label: API / Design Sketch (optional)
+      description: If you have an idea for public API shape, describe it here.
+      render: java
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives / Workarounds
+      description: What else did you consider? Any current workaround?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: breaking_change
+    attributes:
+      label: Would this be a breaking change?
+      options:
+        - "unknown"
+        - "no"
+        - "yes"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority (reporter estimate)
+      options:
+        - low
+        - medium
+        - high
+    validations:
+      required: true
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Related Module
+      options:
+        - api
+        - core
+        - codec
+        - testkit
+        - cli
+        - schema-tools
+        - spring-boot-starter
+        - other / unknown
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I checked existing issues and discussions for duplicates.
+          required: true
+        - label: This request is within the project's scope (not a support question).
+          required: false

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,0 +1,72 @@
+name: ⚡ Performance
+description: Report performance regressions, hotspots, or high resource usage
+title: "[Performance]: "
+labels: ["performance", "needs-triage"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Affected Version
+      placeholder: e.g. 0.5.0 (or main @ <commit>)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - regression (slower than before)
+        - slow operation (always slow)
+        - memory usage / allocations
+        - cpu usage
+        - startup time
+    validations:
+      required: true
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload / Scenario
+      description: Describe the operation, input sizes, and typical usage pattern.
+      placeholder: Include data sizes (e.g. 10k entries), schema complexity, number of fixers, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Performance
+      description: What performance do you expect (baseline)?
+      placeholder: e.g. should complete under X ms for Y input size
+    validations:
+      required: false
+
+  - type: textarea
+    id: measured
+    attributes:
+      label: Measured Performance
+      description: Provide numbers and how you measured them.
+      placeholder: |
+        - Before: ...
+        - After: ...
+        - Measurement method: JMH / integration benchmark / stopwatch
+        - Hardware: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: profiling
+    attributes:
+      label: Profiling Data (optional)
+      description: Attach or paste relevant profiler output (JFR, async-profiler, allocation trace).
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: e.g. Java 21, OS, CPU model, RAM, Maven/Gradle
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,46 @@
+name: ❓ Question
+description: Ask a usage question (not a bug report)
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What are you trying to accomplish?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Relevant details (versions, module, configuration, snippet).
+      placeholder: Paste minimal code/config if relevant.
+      render: java
+    validations:
+      required: false
+
+  - type: textarea
+    id: what_tried
+    attributes:
+      label: What did you try?
+      description: What approaches did you already attempt?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Related Module
+      options:
+        - api
+        - core
+        - codec
+        - testkit
+        - cli
+        - schema-tools
+        - spring-boot-starter
+        - other / unknown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,62 @@
+name: 🔒 Security Report
+description: Report a potential security issue (no sensitive details)
+title: "[Security]: "
+labels: ["security", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ Do NOT include exploit details, credentials, tokens, private keys, or sensitive information.
+        If this is a serious vulnerability, please use GitHub Security Advisories or follow SECURITY.md.
+
+  - type: input
+    id: affected_versions
+    attributes:
+      label: Affected Version(s)
+      placeholder: e.g. 0.5.0, 0.4.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity (reporter estimate)
+      options:
+        - low
+        - medium
+        - high
+        - critical
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary (non-sensitive)
+      description: High-level description of the issue without exploitation steps.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Potential Impact
+      description: What could happen if exploited?
+    validations:
+      required: false
+
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Suggested Mitigation (optional)
+      description: Any ideas on how to fix or mitigate it?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I did not include sensitive exploit details in this public report.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Summary
+Brief description of what this PR does and why.
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] Build / CI
+
+## Related Issues
+Closes #…
+
+## Changes
+- …
+- …
+
+## Verification
+- [ ] Unit tests added/updated
+- [ ] Existing tests pass
+- [ ] Manual verification performed (if applicable)
+
+## Breaking Changes
+Describe any breaking changes or migration steps.
+
+## Checklist
+- [ ] Code follows project conventions
+- [ ] Public APIs are documented
+- [ ] Tests cover new behavior
+- [ ] No unnecessary dependencies added

--- a/.github/workflows/dependabot-retarget-to-develop.yml
+++ b/.github/workflows/dependabot-retarget-to-develop.yml
@@ -1,0 +1,39 @@
+name: Retarget Dependabot PRs to develop
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retarget:
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Change base branch to develop
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Only retarget if it is still targeting main
+            if (pr.base.ref !== 'main') {
+              core.info(`PR base is already '${pr.base.ref}', nothing to do.`);
+              return;
+            }
+
+            core.info(`Retargeting PR #${pr.number} from '${pr.base.ref}' to 'develop'...`);
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              base: 'develop',
+            });
+
+            core.info(`Done. PR #${pr.number} now targets 'develop'.`);


### PR DESCRIPTION
This pull request adds templates for GitHub issues and discussions. The addition aims to standardize communication across the project, ensuring consistency and ease of use for contributors. No functional code changes were made.