### PR TITLE
Update documentation for Aether Datafixers v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,69 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [0.5.0] - 2026-01-12
+## [0.5.0] - 2026-01-16
+
+### API Freeze
+
+This release marks the **API freeze** for Aether Datafixers. The public API is now stable and no breaking changes are expected before v1.0.0.
 
 ### Added
+
+#### SchemaValidator Fix Coverage Integration (`aether-datafixers-schema-tools`)
+
+The `SchemaValidator.validateFixCoverage()` method now performs actual coverage analysis using `MigrationAnalyzer`:
+
+- **Full MigrationAnalyzer integration** — Detects missing DataFixes for schema changes
+- **Automatic version range detection** — Scans the entire schema registry to determine version bounds
+- **Field-level coverage gaps** — Reports issues for added, removed, or modified fields without fixes
+- **Detailed context** — Issues include type, field name, version range, and gap reason
+
+**Usage:**
+```java
+ValidationResult result = SchemaValidator.forBootstrap(bootstrap)
+    .validateFixCoverage()
+    .validate();
+
+for (ValidationIssue issue : result.warnings()) {
+    System.out.println(issue.message());
+    // "Missing DataFix for type 'player' field 'health': FIELD_ADDED"
+}
+```
+
+#### MigrationService.withOps() Implementation (`aether-datafixers-spring-boot-starter`)
+
+The Spring Boot `MigrationService` now fully supports custom `DynamicOps` for format conversion:
+
+- **Format conversion during migration** — Convert input data to specified format before migration
+- **Seamless API integration** — Works with the existing fluent builder API
+- **All formats supported** — Gson, Jackson JSON, YAML (both), TOML, and XML
+
+**Usage:**
+```java
+// Convert Gson data to Jackson YAML format during migration
+MigrationResult result = migrationService
+    .migrate(gsonData)
+    .from(100)
+    .to(200)
+    .withOps(JacksonYamlOps.INSTANCE)
+    .execute();
+
+// Result data is now in Jackson YAML format
+Dynamic<JsonNode> yamlResult = (Dynamic<JsonNode>) result.getData();
+```
+
+#### Functional Tests Module (`aether-datafixers-functional-tests`)
+
+New module with comprehensive end-to-end and integration tests:
+
+- **Cross-format migration tests** — Verify migrations work identically across all DynamicOps implementations
+- **Error recovery tests** — Test graceful handling of malformed data and fix failures
+- **Field transformation E2E tests** — Validate rename, add, remove, and group operations
+
+**Running:**
+```bash
+mvn verify -Pit
+```
 
 #### CLI Format Handlers for YAML, TOML, and XML (`aether-datafixers-cli`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![License](https://img.shields.io/badge/license-MIT-red)
 ![Maven Central](https://img.shields.io/maven-central/v/de.splatgames.aether.datafixers/aether-datafixers)
-![Version](https://img.shields.io/badge/version-0.4.0-orange)
+![Version](https://img.shields.io/badge/version-0.5.0-orange)
 
 # Aether Datafixers 🔧
 
@@ -10,7 +10,7 @@ inspired by Minecraft's DataFixer Upper (DFU), with a focus on **simplicity**, *
 
 ---
 
-## ✨ Features (v0.4.0)
+## ✨ Features (v0.5.0)
 
 - ✅ **Schema-Based Versioning** — Define data types per version with `Schema` and `TypeRegistry`
 - ✅ **Forward Patching** — Apply `DataFix` instances sequentially to migrate data across versions
@@ -25,6 +25,8 @@ inspired by Minecraft's DataFixer Upper (DFU), with a focus on **simplicity**, *
 - ✅ **Migration Diagnostics** — Opt-in structured reports with timing, applied fixes, and snapshots
 - ✅ **Extended Rewrite Rules** — Batch operations, path-based transforms, conditional rules
 - ✅ **High-Performance APIs** — `Rules.batch()` for single-pass multi-operation transforms
+- ✅ **Fix Coverage Validation** — Detect schema changes without corresponding DataFixes
+- ✅ **Extended Codec Support** — Multi-format DynamicOps for CLI and Testkit modules
 - ✅ **JDK 17+** — Built and tested on modern LTS JVMs
 
 ---
@@ -39,6 +41,7 @@ inspired by Minecraft's DataFixer Upper (DFU), with a focus on **simplicity**, *
 - **aether-datafixers-schema-tools** — Schema analysis, validation, diffing, and introspection
 - **aether-datafixers-spring-boot-starter** — Spring Boot 3.x auto-configuration with Actuator support
 - **aether-datafixers-examples** — Practical examples demonstrating real-world usage
+- **aether-datafixers-functional-tests** — End-to-end and integration tests
 - **aether-datafixers-bom** — Bill of Materials for coordinated dependency management
 
 ---
@@ -89,7 +92,7 @@ Dynamic<?> updated = fixer.update(
 <dependency>
     <groupId>de.splatgames.aether.datafixers</groupId>
     <artifactId>aether-datafixers-core</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 
@@ -97,7 +100,7 @@ Dynamic<?> updated = fixer.update(
 
 ```groovy
 dependencies {
-    implementation 'de.splatgames.aether.datafixers:aether-datafixers-core:0.4.0'
+    implementation 'de.splatgames.aether.datafixers:aether-datafixers-core:0.5.0'
 }
 ```
 
@@ -105,7 +108,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("de.splatgames.aether.datafixers:aether-datafixers-core:0.4.0")
+    implementation("de.splatgames.aether.datafixers:aether-datafixers-core:0.5.0")
 }
 ```
 
@@ -125,7 +128,7 @@ The Bill of Materials (BOM) ensures consistent versions across all Aether Datafi
         <dependency>
             <groupId>de.splatgames.aether.datafixers</groupId>
             <artifactId>aether-datafixers-bom</artifactId>
-            <version>0.4.0</version>
+            <version>0.5.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -149,7 +152,7 @@ The Bill of Materials (BOM) ensures consistent versions across all Aether Datafi
 
 ```groovy
 dependencies {
-    implementation platform('de.splatgames.aether.datafixers:aether-datafixers-bom:0.4.0')
+    implementation platform('de.splatgames.aether.datafixers:aether-datafixers-bom:0.5.0')
 
     // No version needed
     implementation 'de.splatgames.aether.datafixers:aether-datafixers-core'
@@ -161,7 +164,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation(platform("de.splatgames.aether.datafixers:aether-datafixers-bom:0.4.0"))
+    implementation(platform("de.splatgames.aether.datafixers:aether-datafixers-bom:0.5.0"))
 
     // No version needed
     implementation("de.splatgames.aether.datafixers:aether-datafixers-core")
@@ -366,14 +369,14 @@ The `aether-datafixers-spring-boot-starter` provides comprehensive Spring Boot 3
 <dependency>
     <groupId>de.splatgames.aether.datafixers</groupId>
     <artifactId>aether-datafixers-spring-boot-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 
 **Gradle (Kotlin)**
 
 ```kotlin
-implementation("de.splatgames.aether.datafixers:aether-datafixers-spring-boot-starter:0.4.0")
+implementation("de.splatgames.aether.datafixers:aether-datafixers-spring-boot-starter:0.5.0")
 ```
 
 ### Quick Start
@@ -562,7 +565,7 @@ mvn test
   - **Fix coverage analysis** — Detect schema changes without corresponding DataFixes
   - **Convention checking** — Enforce naming conventions for types, fields, and classes
 
-- **v0.4.0** (current)
+- **v0.4.0**
   - **Spring Boot Starter** — Auto-configuration, MigrationService with fluent API
   - **Actuator integration** — Health indicator, info contributor, custom endpoint, Micrometer metrics
   - **Multi-domain support** — Multiple DataFixers with @Qualifier annotations
@@ -570,16 +573,17 @@ mvn test
   - **Multi-format DynamicOps** — YAML (SnakeYAML, Jackson), TOML (Jackson), XML (Jackson)
   - **Package restructuring** — Format-first package organization (`codec.json.gson`, `codec.yaml.jackson`, etc.)
 
-- **v0.5.0** (next, API freeze candidate – expect one last missed out feature)
-  - **Codec integration** — Integration of extra codecs for aether-datafixers-testkit and aether-datafixers-cli
-  - **API stabilization pass** — Naming/packaging cleanup + deprecations completed
-  - **Compatibility checks in CI** — Binary/source compatibility guardrails for public API
-  - **Hardened error model** — Consistent exception types + structured error details
-  - **Release readiness** — Final review of docs/examples against frozen API
+- **v0.5.0** (current, API freeze)
+  - **API Freeze** — Public API stabilized, no breaking changes expected before v1.0.0
+  - **Extended Codec Support** — Multi-format DynamicOps integration for CLI, Testkit and Spring Boot modules
+  - **SchemaValidator integration** — Full `MigrationAnalyzer` integration for fix coverage validation
+  - **MigrationService.withOps()** — Custom `DynamicOps` support for format conversion during migrations
+  - **Functional Tests module** — Comprehensive E2E and integration tests
+  - **Comprehensive documentation** — Complete documentation suite covering all modules
 
-- **v1.0.0**
-  - Stable API surface
-  - Comprehensive documentation
+- **v1.0.0** (next)
+  - Stable API surface with semantic versioning guarantees
+  - Performance benchmarks
   - Production-ready release
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,7 +148,7 @@ Seamlessly integrate Aether Datafixers into Spring Boot applications:
 
 | Module                                  | Description                                                         |
 |-----------------------------------------|---------------------------------------------------------------------|
-| `aether-datafixers-api`                 | Core interfaces and API contracts                                   |
+| `aether-datafixers-api`                 | Core interfaces and API contracts (stable)                          |
 | `aether-datafixers-core`                | Default implementations                                             |
 | `aether-datafixers-codec`               | DynamicOps for JSON, YAML, TOML, XML (Gson, Jackson, SnakeYAML)     |
 | `aether-datafixers-spring-boot-starter` | Spring Boot auto-configuration, MigrationService, Actuator, Metrics |
@@ -156,6 +156,7 @@ Seamlessly integrate Aether Datafixers into Spring Boot applications:
 | `aether-datafixers-testkit`             | Testing utilities for DataFix, Schema, and migration testing        |
 | `aether-datafixers-schema-tools`        | Schema analysis, validation, and diffing utilities                  |
 | `aether-datafixers-examples`            | Practical usage examples                                            |
+| `aether-datafixers-functional-tests`    | End-to-end and integration tests                                    |
 | `aether-datafixers-bom`                 | Bill of Materials for version management                            |
 
 ---

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -4,7 +4,42 @@ History of documentation updates. For code changes, see the main [CHANGELOG.md](
 
 ---
 
-## Version 0.5.0
+## Version 0.5.0 (API Freeze)
+
+### API Freeze
+
+Public API is now stable. No breaking changes expected before v1.0.0.
+
+### SchemaValidator Fix Coverage Integration
+
+The `SchemaValidator.validateFixCoverage()` method now performs actual coverage analysis:
+
+- Full integration with `MigrationAnalyzer` for detecting missing DataFixes
+- Automatic version range detection from schema registry
+- Field-level coverage gap detection with detailed context
+- Reports issues as `ValidationIssue` warnings with location and context
+
+Updated documentation:
+- [Schema Validation](../schema-tools/schema-validation.md) — Updated with fix coverage validation examples
+
+### MigrationService.withOps() Support
+
+The Spring Boot `MigrationService` now fully supports custom `DynamicOps`:
+
+- Convert input data to specified format before migration
+- Seamless integration with the fluent API
+- Supports all DynamicOps implementations (Gson, Jackson, YAML, TOML, XML)
+
+Updated documentation:
+- [MigrationService API](../spring-boot/migration-service.md) — Added withOps() usage examples
+
+### Functional Tests Module
+
+New `aether-datafixers-functional-tests` module with comprehensive E2E and integration tests:
+
+- Cross-format migration tests (all DynamicOps implementations)
+- Error recovery integration tests
+- Field transformation E2E tests (rename, add, group)
 
 ### CLI: New Built-in Format Handlers
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -220,7 +220,7 @@ aether-cli info [OPTIONS]
 Without options (or with `--formats`):
 
 ```
-Aether Datafixers CLI v0.4.0
+Aether Datafixers CLI v0.5.0
 ============================
 
 Available Formats:
@@ -233,7 +233,7 @@ Available Formats:
 With `--bootstrap`:
 
 ```
-Aether Datafixers CLI v0.4.0
+Aether Datafixers CLI v0.5.0
 ============================
 
 Bootstrap Information:

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -22,18 +22,18 @@ cd aether-datafixers
 mvn clean install
 
 # The fat JAR is located at:
-# aether-datafixers-cli/target/aether-datafixers-cli-0.4.0-jar-with-dependencies.jar
+# aether-datafixers-cli/target/aether-datafixers-cli-0.5.0-jar-with-dependencies.jar
 ```
 
 ### Verify Installation
 
 ```bash
-java -jar aether-datafixers-cli/target/aether-datafixers-cli-0.4.0-jar-with-dependencies.jar --version
+java -jar aether-datafixers-cli/target/aether-datafixers-cli-0.5.0-jar-with-dependencies.jar --version
 ```
 
 Expected output:
 ```
-Aether Datafixers CLI 0.4.0
+Aether Datafixers CLI 0.5.0
 ```
 
 ---
@@ -45,7 +45,7 @@ Aether Datafixers CLI 0.4.0
 Run the CLI directly with `java -jar`:
 
 ```bash
-java -jar aether-datafixers-cli-0.4.0-jar-with-dependencies.jar migrate \
+java -jar aether-datafixers-cli-0.5.0-jar-with-dependencies.jar migrate \
     --to 200 \
     --type player \
     --bootstrap com.example.MyBootstrap \
@@ -57,7 +57,7 @@ java -jar aether-datafixers-cli-0.4.0-jar-with-dependencies.jar migrate \
 Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
-alias aether-cli='java -jar /path/to/aether-datafixers-cli-0.4.0-jar-with-dependencies.jar'
+alias aether-cli='java -jar /path/to/aether-datafixers-cli-0.5.0-jar-with-dependencies.jar'
 ```
 
 Then use:
@@ -72,7 +72,7 @@ Create `aether-cli.bat`:
 
 ```batch
 @echo off
-java -jar "C:\path\to\aether-datafixers-cli-0.4.0-jar-with-dependencies.jar" %*
+java -jar "C:\path\to\aether-datafixers-cli-0.5.0-jar-with-dependencies.jar" %*
 ```
 
 Add the directory to your PATH, then use:
@@ -105,7 +105,7 @@ The CLI needs access to your `DataFixerBootstrap` implementation. There are seve
 Add your bootstrap JAR to the classpath:
 
 ```bash
-java -cp "aether-datafixers-cli-0.4.0-jar-with-dependencies.jar:my-bootstrap.jar" \
+java -cp "aether-datafixers-cli-0.5.0-jar-with-dependencies.jar:my-bootstrap.jar" \
     de.splatgames.aether.datafixers.cli.AetherCli \
     migrate --to 200 --type player --bootstrap com.example.MyBootstrap input.json
 ```
@@ -122,7 +122,7 @@ Create a custom fat JAR that includes both the CLI and your bootstrap:
     <dependency>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers-cli</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </dependency>
 </dependencies>
 
@@ -151,7 +151,7 @@ Create a custom fat JAR that includes both the CLI and your bootstrap:
 During development, point to compiled classes:
 
 ```bash
-java -cp "aether-datafixers-cli-0.4.0-jar-with-dependencies.jar:target/classes" \
+java -cp "aether-datafixers-cli-0.5.0-jar-with-dependencies.jar:target/classes" \
     de.splatgames.aether.datafixers.cli.AetherCli \
     migrate --to 200 --type player --bootstrap com.example.MyBootstrap input.json
 ```
@@ -168,14 +168,14 @@ To use the CLI as a dependency in your project (for programmatic access):
 <dependency>
     <groupId>de.splatgames.aether.datafixers</groupId>
     <artifactId>aether-datafixers-cli</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'de.splatgames.aether.datafixers:aether-datafixers-cli:0.4.0'
+implementation 'de.splatgames.aether.datafixers:aether-datafixers-cli:0.5.0'
 ```
 
 ---

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ Add the core dependency to your `pom.xml`:
 <dependency>
     <groupId>de.splatgames.aether</groupId>
     <artifactId>aether-datafixers-core</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 
@@ -38,12 +38,12 @@ Add the core dependency to your `pom.xml`:
     <dependency>
         <groupId>de.splatgames.aether</groupId>
         <artifactId>aether-datafixers-core</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </dependency>
     <dependency>
         <groupId>de.splatgames.aether</groupId>
         <artifactId>aether-datafixers-codec</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </dependency>
     <!-- Gson is optional in codec module, add explicitly -->
     <dependency>
@@ -63,18 +63,18 @@ Add the testkit module for unit testing your migrations:
     <dependency>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers-core</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </dependency>
     <dependency>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers-codec</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
     </dependency>
     <!-- Testkit for unit testing -->
     <dependency>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers-testkit</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
@@ -90,7 +90,7 @@ The Bill of Materials (BOM) ensures consistent versions across all modules:
         <dependency>
             <groupId>de.splatgames.aether.datafixers</groupId>
             <artifactId>aether-datafixers-bom</artifactId>
-            <version>0.4.0</version>
+            <version>0.5.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -124,7 +124,7 @@ The Bill of Materials (BOM) ensures consistent versions across all modules:
 
 ```groovy
 dependencies {
-    implementation 'de.splatgames.aether:aether-datafixers-core:0.4.0'
+    implementation 'de.splatgames.aether:aether-datafixers-core:0.5.0'
 }
 ```
 
@@ -132,8 +132,8 @@ With JSON support:
 
 ```groovy
 dependencies {
-    implementation 'de.splatgames.aether:aether-datafixers-core:0.4.0'
-    implementation 'de.splatgames.aether:aether-datafixers-codec:0.4.0'
+    implementation 'de.splatgames.aether:aether-datafixers-core:0.5.0'
+    implementation 'de.splatgames.aether:aether-datafixers-codec:0.5.0'
     implementation 'com.google.code.gson:gson:2.13.2'
 }
 ```
@@ -142,7 +142,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("de.splatgames.aether:aether-datafixers-core:0.4.0")
+    implementation("de.splatgames.aether:aether-datafixers-core:0.5.0")
 }
 ```
 
@@ -150,8 +150,8 @@ With JSON support:
 
 ```kotlin
 dependencies {
-    implementation("de.splatgames.aether:aether-datafixers-core:0.4.0")
-    implementation("de.splatgames.aether:aether-datafixers-codec:0.4.0")
+    implementation("de.splatgames.aether:aether-datafixers-core:0.5.0")
+    implementation("de.splatgames.aether:aether-datafixers-codec:0.5.0")
     implementation("com.google.code.gson:gson:2.13.2")
 }
 ```
@@ -160,9 +160,9 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'de.splatgames.aether.datafixers:aether-datafixers-core:0.4.0'
-    implementation 'de.splatgames.aether.datafixers:aether-datafixers-codec:0.4.0'
-    testImplementation 'de.splatgames.aether.datafixers:aether-datafixers-testkit:0.4.0'
+    implementation 'de.splatgames.aether.datafixers:aether-datafixers-core:0.5.0'
+    implementation 'de.splatgames.aether.datafixers:aether-datafixers-codec:0.5.0'
+    testImplementation 'de.splatgames.aether.datafixers:aether-datafixers-testkit:0.5.0'
 }
 ```
 
@@ -172,7 +172,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation platform('de.splatgames.aether.datafixers:aether-datafixers-bom:0.4.0')
+    implementation platform('de.splatgames.aether.datafixers:aether-datafixers-bom:0.5.0')
 
     // No version needed
     implementation 'de.splatgames.aether.datafixers:aether-datafixers-core'
@@ -185,7 +185,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation(platform("de.splatgames.aether.datafixers:aether-datafixers-bom:0.4.0"))
+    implementation(platform("de.splatgames.aether.datafixers:aether-datafixers-bom:0.5.0"))
 
     // No version needed
     implementation("de.splatgames.aether.datafixers:aether-datafixers-core")

--- a/docs/tutorials/basic-migration.md
+++ b/docs/tutorials/basic-migration.md
@@ -30,12 +30,12 @@ Add the dependencies to your project:
 <dependency>
     <groupId>de.splatgames.aether</groupId>
     <artifactId>aether-datafixers-core</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
 </dependency>
 <dependency>
     <groupId>de.splatgames.aether</groupId>
     <artifactId>aether-datafixers-codec</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
 </dependency>
 <dependency>
     <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
- **Summary of Changes**  
  This pull request updates documentation, examples, and related files to align with the Aether Datafixers v0.5.0 release. It includes:  
  - Dependency version updates to `0.5.0` across installation guides and tutorials.  
  - Revised `README.md`, `RELEASE.md`, and `CHANGELOG.md` to reflect the API freeze and the addition of new features:  
    - SchemaValidator coverage integration with `MigrationAnalyzer`.  
    - Support for custom `DynamicOps` to assist format conversion in the `MigrationService`.  
    - Introduction of the `functional-tests` module for end-to-end testing.  
    - Enhanced codec support for CLI and Testkit with new format handlers.

- **Checklist**  
  - [x] Documentation has been updated as needed.  
  - [x] New features are clearly described in the corresponding files.  
  - [x] Examples reflect the latest functionality.