### PR TITLE
Fix Javadoc typos in TypeDiff and DataVersion

### DIFF
--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/DataVersion.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/DataVersion.java
@@ -135,7 +135,7 @@ public final class DataVersion implements Comparable<DataVersion> {
      * }</pre>
      *
      * @param o the data version to compare against; must not be {@code null}
-     * @return a negative integer if this version is less than the specified version, zero if they are equal, or a al,
+     * @return a negative integer if this version is less than the specified version, zero if they are equal,
      * or a positive integer if this version is greater than the specified version
      * @throws NullPointerException if the specified data version is {@code null}
      */

--- a/aether-datafixers-schema-tools/src/main/java/de/splatgames/aether/datafixers/schematools/diff/TypeDiff.java
+++ b/aether-datafixers-schema-tools/src/main/java/de/splatgames/aether/datafixers/schematools/diff/TypeDiff.java
@@ -199,7 +199,7 @@ public final class TypeDiff {
 
     /**
      * Returns only the removed fields.
-     *f
+     *
      * @return a list of field diffs with kind REMOVED, never {@code null}
      */
     @NotNull


### PR DESCRIPTION
## Summary

- **TypeDiff.removedFields()** (#175): Removed stray `f` character from Javadoc comment
- **DataVersion.compareTo()** (#132): Fixed garbled text `"or a al, or a"` in `@return` tag

Fixes #175
Fixes #132