### PR TITLE
Add equals/hashCode to MigrationResult

### DIFF
--- a/aether-datafixers-spring-boot-starter/src/main/java/de/splatgames/aether/datafixers/spring/service/MigrationResult.java
+++ b/aether-datafixers-spring-boot-starter/src/main/java/de/splatgames/aether/datafixers/spring/service/MigrationResult.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -120,8 +121,8 @@ import java.util.Optional;
  * shared between threads without synchronization.</p>
  *
  * <h2>Equality and Hashing</h2>
- * <p>This class does not override {@code equals()} and {@code hashCode()}.
- * Each instance is unique and identity-based comparison is used.</p>
+ * <p>Two {@code MigrationResult} instances are considered equal if they have the same
+ * success status, source and target versions, domain, and duration.</p>
  *
  * @author Erik Pförtner
  * @see MigrationService
@@ -427,6 +428,46 @@ public final class MigrationResult {
      */
     public int getVersionSpan() {
         return Math.abs(this.toVersion.getVersion() - this.fromVersion.getVersion());
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this migration result.
+     *
+     * <p>Two {@code MigrationResult} instances are considered equal if and only if they
+     * have the same success status, source version, target version, domain, and duration.</p>
+     *
+     * @param obj the reference object with which to compare; may be {@code null}
+     * @return {@code true} if this result is equal to the specified object; {@code false} otherwise
+     * @see #hashCode()
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof MigrationResult other)) {
+            return false;
+        }
+        return this.success == other.success
+                && Objects.equals(this.fromVersion, other.fromVersion)
+                && Objects.equals(this.toVersion, other.toVersion)
+                && Objects.equals(this.domain, other.domain)
+                && Objects.equals(this.duration, other.duration);
+    }
+
+    /**
+     * Returns a hash code value for this migration result.
+     *
+     * <p>The hash code is computed based on the success status, source version, target version,
+     * domain, and duration. This implementation satisfies the general contract of
+     * {@link Object#hashCode()}.</p>
+     *
+     * @return a hash code value for this migration result
+     * @see #equals(Object)
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.success, this.fromVersion, this.toVersion, this.domain, this.duration);
     }
 
     /**

--- a/aether-datafixers-spring-boot-starter/src/test/java/de/splatgames/aether/datafixers/spring/service/MigrationResultTest.java
+++ b/aether-datafixers-spring-boot-starter/src/test/java/de/splatgames/aether/datafixers/spring/service/MigrationResultTest.java
@@ -238,6 +238,83 @@ class MigrationResultTest {
     }
 
     @Nested
+    @DisplayName("equals and hashCode")
+    class EqualsAndHashCode {
+
+        @Test
+        @DisplayName("equals() returns true for same values")
+        void equalsReturnsTrueForSameValues() {
+            TaggedDynamic data = mock(TaggedDynamic.class);
+
+            MigrationResult a = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+            MigrationResult b = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+
+            assertThat(a).isEqualTo(b);
+        }
+
+        @Test
+        @DisplayName("equals() returns false for different success status")
+        void equalsReturnsFalseForDifferentSuccess() {
+            TaggedDynamic data = mock(TaggedDynamic.class);
+
+            MigrationResult success = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+            MigrationResult failure = MigrationResult.failure(
+                    FROM_VERSION, TO_VERSION, DOMAIN, DURATION, new RuntimeException("error")
+            );
+
+            assertThat(success).isNotEqualTo(failure);
+        }
+
+        @Test
+        @DisplayName("equals() returns false for different versions")
+        void equalsReturnsFalseForDifferentVersions() {
+            TaggedDynamic data = mock(TaggedDynamic.class);
+
+            MigrationResult a = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+            MigrationResult b = MigrationResult.success(
+                    data, FROM_VERSION, new DataVersion(300), DOMAIN, DURATION
+            );
+
+            assertThat(a).isNotEqualTo(b);
+        }
+
+        @Test
+        @DisplayName("hashCode() is consistent for equal objects")
+        void hashCodeConsistentForEqualObjects() {
+            TaggedDynamic data = mock(TaggedDynamic.class);
+
+            MigrationResult a = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+            MigrationResult b = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+
+            assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        }
+
+        @Test
+        @DisplayName("equals() returns false for null")
+        void equalsReturnsFalseForNull() {
+            TaggedDynamic data = mock(TaggedDynamic.class);
+
+            MigrationResult result = MigrationResult.success(
+                    data, FROM_VERSION, TO_VERSION, DOMAIN, DURATION
+            );
+
+            assertThat(result).isNotEqualTo(null);
+        }
+    }
+
+    @Nested
     @DisplayName("toString")
     class ToStringMethod {
 


### PR DESCRIPTION
## Summary

Implement value-based `equals()` and `hashCode()` for `MigrationResult`, based on success status, source/target versions, domain, and duration.

This replaces the identity-based comparison noted in the class Javadoc, making it safe to use `MigrationResult` in collections and assertions.

## Changes

**`MigrationResult.java`:**
- Added `equals()` using `instanceof` pattern matching (matching `DataVersion` style)
- Added `hashCode()` using `Objects.hash()`
- Updated class Javadoc to reflect value-based equality
- Added `java.util.Objects` import

**`MigrationResultTest.java`:**
- Added 5 tests in new `EqualsAndHashCode` nested class:
  - Equal values → `equals()` returns true
  - Different success status → returns false
  - Different versions → returns false
  - Equal objects → consistent `hashCode()`
  - Null → returns false

Fixes #222