### PR TITLE
Standardize documentation formatting and fix Javadoc issues

### DIFF
--- a/.github/workflows/retarget-pr-to-develop.yml
+++ b/.github/workflows/retarget-pr-to-develop.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::notice::PR #${{ github.event.pull_request.number }} targets main from '${{ github.head_ref }}' — retargeting to develop."
+          echo "::notice::PR #${{ github.event.pull_request.number }} targets main from '${{ github.head_ref }}' - retargeting to develop."
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --base develop

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -1,6 +1,6 @@
 # 🤖 AI Usage Guidelines
 
-Aether Datafixers permits the use of AI tools in contributions — but under strict conditions. Transparency, quality, and human accountability are **non-negotiable**. This document defines the rules that all contributors and maintainers must follow when using AI-assisted tooling.
+Aether Datafixers permits the use of AI tools in contributions - but under strict conditions. Transparency, quality, and human accountability are **non-negotiable**. This document defines the rules that all contributors and maintainers must follow when using AI-assisted tooling.
 
 ---
 
@@ -31,11 +31,11 @@ This policy applies to all forms of contribution:
 
 ## ⚖️ General Principles
 
-1. **AI is a tool, humans are accountable.** AI does not author contributions — humans do. The person who submits AI-assisted work bears full responsibility for it.
-2. **Same quality bar — no exceptions.** AI-generated output must meet the exact same standards as human-written code: conventions, tests, documentation, and review.
+1. **AI is a tool, humans are accountable.** AI does not author contributions - humans do. The person who submits AI-assisted work bears full responsibility for it.
+2. **Same quality bar - no exceptions.** AI-generated output must meet the exact same standards as human-written code: conventions, tests, documentation, and review.
 3. **Transparency is mandatory.** Disclosure of significant AI assistance is required, not optional. Honest disclosure is always better than concealment.
 4. **Quality and security over speed.** AI can accelerate development, but speed must never come at the expense of correctness, maintainability, or security.
-5. **When in doubt, write it yourself.** If you are unsure whether AI output is correct, secure, or license-compatible — do not submit it. Rewrite it by hand.
+5. **When in doubt, write it yourself.** If you are unsure whether AI output is correct, secure, or license-compatible - do not submit it. Rewrite it by hand.
 
 ---
 
@@ -47,7 +47,7 @@ AI tools may be used in the following areas, subject to the conditions listed:
 |---------------------------------------|-----------|-------------------------------------------------------------------|
 | Code generation (features, bug fixes) | ✅ Allowed | Must be fully understood, tested, and reviewed by the contributor |
 | Test generation (JUnit 5 / AssertJ)   | ✅ Allowed | Assertions and edge cases must be manually verified               |
-| Documentation and Javadoc             | ✅ Allowed | Must be factually accurate — AI may hallucinate API details       |
+| Documentation and Javadoc             | ✅ Allowed | Must be factually accurate - AI may hallucinate API details       |
 | Boilerplate and scaffolding           | ✅ Allowed | Still requires review for project conventions                     |
 | Commit message drafting               | ✅ Allowed | Must accurately describe the actual changes                       |
 | PR description drafting               | ✅ Allowed | Must reflect the real changes, not AI assumptions                 |
@@ -60,11 +60,11 @@ AI tools may be used in the following areas, subject to the conditions listed:
 
 ## 🚫 Restricted & Prohibited Uses
 
-### 🏷️ Good First Issues — Learning First
+### 🏷️ Good First Issues - Learning First
 
 Issues labeled **`good first issue`** are **strongly encouraged** to be completed **primarily without significant AI assistance**.  
 
-**Why:** Good first issues exist to help new contributors learn the codebase and ramp up through hands-on experience. They are intentionally kept simple. Solving them with your own effort lets you truly understand the project’s structure, patterns, and conventions — and keeps the opportunity fair for everyone who wants to make their first contribution through genuine learning.
+**Why:** Good first issues exist to help new contributors learn the codebase and ramp up through hands-on experience. They are intentionally kept simple. Solving them with your own effort lets you truly understand the project’s structure, patterns, and conventions - and keeps the opportunity fair for everyone who wants to make their first contribution through genuine learning.
 
 If you are new to the project, embrace these issues as a learning opportunity. If you are experienced enough to use AI effectively, you are welcome to pick a more challenging issue instead.
 
@@ -74,21 +74,21 @@ If you are new to the project, embrace these issues as a learning opportunity. I
 
 The following areas require **extra scrutiny and maintainer approval** before AI-assisted contributions are accepted:
 
-- **Security-sensitive code** — Any code handling untrusted data through `DynamicOps`, cryptographic operations, or artifact signing. Must be thoroughly reviewed by a maintainer with security context. See [SECURITY.md](SECURITY.md).
-- **Public API design** — AI may suggest API shapes, but public API decisions must be made deliberately by maintainers. AI suggestions must not be accepted wholesale.
-- **Core optics and type system changes** — Changes to the optic hierarchy (`Lens`, `Prism`, `Iso`, `Affine`, `Traversal`) or the type system require deep domain understanding that AI tools may lack.
-- **CI/CD pipeline modifications** — Changes to GitHub Actions workflows, Maven profiles, or build configuration require maintainer review for security and correctness.
+- **Security-sensitive code** - Any code handling untrusted data through `DynamicOps`, cryptographic operations, or artifact signing. Must be thoroughly reviewed by a maintainer with security context. See [SECURITY.md](SECURITY.md).
+- **Public API design** - AI may suggest API shapes, but public API decisions must be made deliberately by maintainers. AI suggestions must not be accepted wholesale.
+- **Core optics and type system changes** - Changes to the optic hierarchy (`Lens`, `Prism`, `Iso`, `Affine`, `Traversal`) or the type system require deep domain understanding that AI tools may lack.
+- **CI/CD pipeline modifications** - Changes to GitHub Actions workflows, Maven profiles, or build configuration require maintainer review for security and correctness.
 
 ### 🚫 Prohibited Uses
 
 The following uses of AI are **not permitted**:
 
-- **AI as sole code reviewer** — Every PR must be reviewed and approved by at least one human maintainer. AI review tools may supplement but never replace human review.
-- **Submitting unreviewed AI output** — Copy-pasting AI-generated code without reading, understanding, and verifying it is prohibited. You must be able to explain every line you submit.
-- **Undisclosed significant AI usage** — Knowingly concealing significant AI assistance violates this policy. See [Accountability](#-accountability).
-- **AI-generated vulnerability reports** — Automated AI scanning to generate public vulnerability reports is prohibited. Follow the private disclosure process in [SECURITY.md](SECURITY.md).
-- **Bypassing project standards** — Using AI to circumvent tests, Checkstyle rules, or other quality gates is prohibited.
-- **AI for license or legal decisions** — AI tools must not be relied upon for license compatibility analysis, DCO compliance interpretation, or other legal matters.
+- **AI as sole code reviewer** - Every PR must be reviewed and approved by at least one human maintainer. AI review tools may supplement but never replace human review.
+- **Submitting unreviewed AI output** - Copy-pasting AI-generated code without reading, understanding, and verifying it is prohibited. You must be able to explain every line you submit.
+- **Undisclosed significant AI usage** - Knowingly concealing significant AI assistance violates this policy. See [Accountability](#-accountability).
+- **AI-generated vulnerability reports** - Automated AI scanning to generate public vulnerability reports is prohibited. Follow the private disclosure process in [SECURITY.md](SECURITY.md).
+- **Bypassing project standards** - Using AI to circumvent tests, Checkstyle rules, or other quality gates is prohibited.
+- **AI for license or legal decisions** - AI tools must not be relied upon for license compatibility analysis, DCO compliance interpretation, or other legal matters.
 
 ---
 
@@ -100,7 +100,7 @@ Disclosure of AI assistance is **mandatory**. This is the most important operati
 
 Disclosure is required whenever AI tools were used to **generate or substantially modify** code, documentation, or other contributions.
 
-**Rule of thumb:** If the AI produced a block of code, a paragraph of text, or a test case that you then submitted — even if you edited it afterward — disclose it.
+**Rule of thumb:** If the AI produced a block of code, a paragraph of text, or a test case that you then submitted - even if you edited it afterward - disclose it.
 
 **Exempt:** Minor AI-assisted tasks such as IDE autocomplete suggestions, spell-checking, or grammar corrections do not require disclosure.
 
@@ -161,14 +161,14 @@ AI-generated code must meet the same standards as human-written code:
 - ✅ Include proper Javadoc for all public API methods
 - ✅ Use JetBrains annotations (`@NotNull`, `@Nullable`) where appropriate
 - ✅ Use Guava `Preconditions` for argument validation
-- ✅ Maintain thread-safety invariants — Aether Datafixers types are immutable and thread-safe by design
+- ✅ Maintain thread-safety invariants - Aether Datafixers types are immutable and thread-safe by design
 - ✅ Not introduce unnecessary dependencies
 
 ### Documentation Quality
 
 AI-generated documentation must:
 
-- ✅ Be **factually accurate** — AI tools frequently hallucinate API details, method signatures, and module names
+- ✅ Be **factually accurate** - AI tools frequently hallucinate API details, method signatures, and module names
 - ✅ Be **consistent** with existing documentation style and structure
 - ✅ Reference **correct** class, method, and module names
 - ✅ Not contradict existing documentation
@@ -185,16 +185,16 @@ AI-assisted PRs follow the same review process as all other PRs (see [CONTRIBUTI
 
 ### Additional Review Focus Areas
 
-- **Test quality** — AI-generated tests may appear comprehensive but miss edge cases, test only happy paths, or contain incorrect assertions. Review assertions carefully.
-- **Hallucinated APIs** — AI may reference methods, classes, or modules that do not exist in this project. Verify all API references against the actual codebase.
-- **Naming conventions** — AI-generated names may not match project conventions (e.g., `DataVersion` vs. `Version`, `TypeReference` vs. `TypeRef`). Enforce consistency.
-- **Thread safety** — Verify that AI-generated code maintains the project's immutability and thread-safety invariants.
-- **Dependency additions** — AI may suggest adding external libraries. Verify necessity and license compatibility.
-- **Subtle logic errors** — AI-generated code can appear correct at first glance while containing subtle bugs. Review logic paths carefully.
+- **Test quality** - AI-generated tests may appear comprehensive but miss edge cases, test only happy paths, or contain incorrect assertions. Review assertions carefully.
+- **Hallucinated APIs** - AI may reference methods, classes, or modules that do not exist in this project. Verify all API references against the actual codebase.
+- **Naming conventions** - AI-generated names may not match project conventions (e.g., `DataVersion` vs. `Version`, `TypeReference` vs. `TypeRef`). Enforce consistency.
+- **Thread safety** - Verify that AI-generated code maintains the project's immutability and thread-safety invariants.
+- **Dependency additions** - AI may suggest adding external libraries. Verify necessity and license compatibility.
+- **Subtle logic errors** - AI-generated code can appear correct at first glance while containing subtle bugs. Review logic paths carefully.
 
 ### Human Review Requirement
 
-- At least **one human maintainer** must review and approve every PR — no exceptions.
+- At least **one human maintainer** must review and approve every PR - no exceptions.
 - Reviewers may request the contributor to **explain** any AI-generated code.
 - Reviewers are not expected to detect undisclosed AI usage. The disclosure responsibility lies with the contributor.
 
@@ -223,7 +223,7 @@ When reviewing and merging AI agent PRs (e.g., from `copilot-swe-agent[bot]`):
 
 ## ⚖️ Intellectual Property & Licensing
 
-All contributions — whether human-written or AI-assisted — must be compatible with the project's [MIT License](LICENSE).
+All contributions - whether human-written or AI-assisted - must be compatible with the project's [MIT License](LICENSE).
 
 ### DCO and AI
 
@@ -244,13 +244,13 @@ By submitting AI-assisted code and signing off with the [Developer Certificate o
 
 ### Responsibility
 
-- The **human contributor** who submits AI-assisted work is **fully responsible** for it — including bugs, security vulnerabilities, test failures, and convention violations.
+- The **human contributor** who submits AI-assisted work is **fully responsible** for it - including bugs, security vulnerabilities, test failures, and convention violations.
 - For **AI agent PRs** (where no human is the commit author), the maintainer who requested the agent's work and/or merged the PR assumes responsibility.
 - "The AI generated it" is **not** a mitigating factor for quality issues or policy violations.
 
 ### Enforcement
 
-- Violations of this policy — particularly **undisclosed AI usage** or **submitting unreviewed AI output** — will be handled constructively on a case-by-case basis.
+- Violations of this policy - particularly **undisclosed AI usage** or **submitting unreviewed AI output** - will be handled constructively on a case-by-case basis.
 - Repeated or intentional violations may be escalated through the project's [Code of Conduct](CODE_OF_CONDUCT.md) enforcement process.
 - Serious violations (e.g., knowingly submitting AI-generated code with license conflicts) may result in **contribution restrictions**.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ This release marks the **API freeze** for Aether Datafixers. The public API is n
 
 The `SchemaValidator.validateFixCoverage()` method now performs actual coverage analysis using `MigrationAnalyzer`:
 
-- **Full MigrationAnalyzer integration** — Detects missing DataFixes for schema changes
-- **Automatic version range detection** — Scans the entire schema registry to determine version bounds
-- **Field-level coverage gaps** — Reports issues for added, removed, or modified fields without fixes
-- **Detailed context** — Issues include type, field name, version range, and gap reason
+- **Full MigrationAnalyzer integration** - Detects missing DataFixes for schema changes
+- **Automatic version range detection** - Scans the entire schema registry to determine version bounds
+- **Field-level coverage gaps** - Reports issues for added, removed, or modified fields without fixes
+- **Detailed context** - Issues include type, field name, version range, and gap reason
 
 **Usage:**
 ```java
@@ -39,9 +39,9 @@ for (ValidationIssue issue : result.warnings()) {
 
 The Spring Boot `MigrationService` now fully supports custom `DynamicOps` for format conversion:
 
-- **Format conversion during migration** — Convert input data to specified format before migration
-- **Seamless API integration** — Works with the existing fluent builder API
-- **All formats supported** — Gson, Jackson JSON, YAML (both), TOML, and XML
+- **Format conversion during migration** - Convert input data to specified format before migration
+- **Seamless API integration** - Works with the existing fluent builder API
+- **All formats supported** - Gson, Jackson JSON, YAML (both), TOML, and XML
 
 **Usage:**
 ```java
@@ -61,9 +61,9 @@ Dynamic<JsonNode> yamlResult = (Dynamic<JsonNode>) result.getData();
 
 New module with comprehensive end-to-end and integration tests:
 
-- **Cross-format migration tests** — Verify migrations work identically across all DynamicOps implementations
-- **Error recovery tests** — Test graceful handling of malformed data and fix failures
-- **Field transformation E2E tests** — Validate rename, add, remove, and group operations
+- **Cross-format migration tests** - Verify migrations work identically across all DynamicOps implementations
+- **Error recovery tests** - Test graceful handling of malformed data and fix failures
+- **Field transformation E2E tests** - Validate rename, add, remove, and group operations
 
 **Running:**
 ```bash
@@ -75,14 +75,14 @@ mvn verify -Pit
 Extended the CLI with four new built-in format handlers:
 
 **YAML Support:**
-- `YamlSnakeYamlFormatHandler` — Format ID `yaml-snakeyaml`, uses SnakeYAML with native Java types
-- `YamlJacksonFormatHandler` — Format ID `yaml-jackson`, uses Jackson YAML with JsonNode
+- `YamlSnakeYamlFormatHandler` - Format ID `yaml-snakeyaml`, uses SnakeYAML with native Java types
+- `YamlJacksonFormatHandler` - Format ID `yaml-jackson`, uses Jackson YAML with JsonNode
 
 **TOML Support:**
-- `TomlJacksonFormatHandler` — Format ID `toml-jackson`, uses Jackson TOML with JsonNode
+- `TomlJacksonFormatHandler` - Format ID `toml-jackson`, uses Jackson TOML with JsonNode
 
 **XML Support:**
-- `XmlJacksonFormatHandler` — Format ID `xml-jackson`, uses Jackson XML with JsonNode
+- `XmlJacksonFormatHandler` - Format ID `xml-jackson`, uses Jackson XML with JsonNode
 
 **Usage Examples:**
 ```bash
@@ -171,10 +171,10 @@ Dynamic<JsonNode> xmlData = TestData.jacksonXml().object()
 
 Added test classes for all new format handlers with full coverage:
 
-- `YamlSnakeYamlFormatHandlerTest` — 21 tests for SnakeYAML handler
-- `YamlJacksonFormatHandlerTest` — 20 tests for Jackson YAML handler
-- `TomlJacksonFormatHandlerTest` — 19 tests for Jackson TOML handler
-- `XmlJacksonFormatHandlerTest` — 20 tests for Jackson XML handler
+- `YamlSnakeYamlFormatHandlerTest` - 21 tests for SnakeYAML handler
+- `YamlJacksonFormatHandlerTest` - 20 tests for Jackson YAML handler
+- `TomlJacksonFormatHandlerTest` - 19 tests for Jackson TOML handler
+- `XmlJacksonFormatHandlerTest` - 20 tests for Jackson XML handler
 
 Tests cover parsing, serialization, error handling, and round-trip consistency.
 
@@ -239,15 +239,15 @@ de.splatgames.aether.datafixers.codec.xml.jackson.JacksonXmlOps
 New DynamicOps implementations for YAML, TOML, and XML formats:
 
 **YAML Support:**
-- `SnakeYamlOps` — Uses native Java types (`Map`, `List`, primitives) via SnakeYAML 2.x
-- `JacksonYamlOps` — Uses `JsonNode` via Jackson YAML dataformat module
+- `SnakeYamlOps` - Uses native Java types (`Map`, `List`, primitives) via SnakeYAML 2.x
+- `JacksonYamlOps` - Uses `JsonNode` via Jackson YAML dataformat module
 
 **TOML Support:**
-- `JacksonTomlOps` — Uses `JsonNode` via Jackson TOML dataformat module
+- `JacksonTomlOps` - Uses `JsonNode` via Jackson TOML dataformat module
 - Note: TOML requires top-level tables and doesn't support null values
 
 **XML Support:**
-- `JacksonXmlOps` — Uses `JsonNode` via Jackson XML dataformat module
+- `JacksonXmlOps` - Uses `JsonNode` via Jackson XML dataformat module
 - Note: XML requires a root element and has different structural semantics
 
 **New Dependencies (all optional):**
@@ -280,32 +280,32 @@ New DynamicOps implementations for YAML, TOML, and XML formats:
 New module providing seamless Spring Boot integration with auto-configuration, fluent migration API, and observability features.
 
 **Auto-Configuration (`spring.autoconfigure`):**
-- `AetherDataFixersAutoConfiguration` — Main entry point coordinating all sub-configurations
-- `DynamicOpsAutoConfiguration` — Auto-configures `GsonOps` and `JacksonOps` beans based on classpath
-- `DataFixerAutoConfiguration` — Creates `AetherDataFixer` beans from `DataFixerBootstrap` definitions
-- `MigrationServiceAutoConfiguration` — Configures the `MigrationService` with metrics integration
-- `ActuatorAutoConfiguration` — Configures health indicators, info contributors, and custom endpoints
+- `AetherDataFixersAutoConfiguration` - Main entry point coordinating all sub-configurations
+- `DynamicOpsAutoConfiguration` - Auto-configures `GsonOps` and `JacksonOps` beans based on classpath
+- `DataFixerAutoConfiguration` - Creates `AetherDataFixer` beans from `DataFixerBootstrap` definitions
+- `MigrationServiceAutoConfiguration` - Configures the `MigrationService` with metrics integration
+- `ActuatorAutoConfiguration` - Configures health indicators, info contributors, and custom endpoints
 - Conditional activation via `aether.datafixers.enabled` property (default: `true`)
 - Version resolution from properties, bootstrap `CURRENT_VERSION` constant, or global default
 
 **Configuration Properties (`spring.config`):**
-- `AetherDataFixersProperties` — Root configuration with `aether.datafixers.*` prefix
-- `DataFixerDomainProperties` — Per-domain configuration (version, primary, description)
-- `DynamicOpsFormat` — Enum for selecting default serialization format:
-  - `GSON` — JSON via Google Gson
-  - `JACKSON` — JSON via Jackson Databind
-  - `JACKSON_YAML` — YAML via Jackson dataformat
-  - `SNAKEYAML` — YAML via SnakeYAML (native Java types)
-  - `JACKSON_TOML` — TOML via Jackson dataformat
-  - `JACKSON_XML` — XML via Jackson dataformat
-- `ActuatorProperties` — Control schema/fix detail exposure in actuator responses
-- `MetricsProperties` — Configure timing, counting, and domain tag name
+- `AetherDataFixersProperties` - Root configuration with `aether.datafixers.*` prefix
+- `DataFixerDomainProperties` - Per-domain configuration (version, primary, description)
+- `DynamicOpsFormat` - Enum for selecting default serialization format:
+  - `GSON` - JSON via Google Gson
+  - `JACKSON` - JSON via Jackson Databind
+  - `JACKSON_YAML` - YAML via Jackson dataformat
+  - `SNAKEYAML` - YAML via SnakeYAML (native Java types)
+  - `JACKSON_TOML` - TOML via Jackson dataformat
+  - `JACKSON_XML` - XML via Jackson dataformat
+- `ActuatorProperties` - Control schema/fix detail exposure in actuator responses
+- `MetricsProperties` - Configure timing, counting, and domain tag name
 
 **Migration Service (`spring.service`):**
-- `MigrationService` — High-level interface with fluent builder API
-- `MigrationService.MigrationRequestBuilder` — Builder for configuring migrations
-- `DefaultMigrationService` — Thread-safe implementation with metrics integration
-- `MigrationResult` — Immutable result object with success/failure, data, versions, duration, error
+- `MigrationService` - High-level interface with fluent builder API
+- `MigrationService.MigrationRequestBuilder` - Builder for configuring migrations
+- `DefaultMigrationService` - Thread-safe implementation with metrics integration
+- `MigrationResult` - Immutable result object with success/failure, data, versions, duration, error
 - Fluent API: `.migrate(data).from(version).to(version).execute()`
 - Domain selection: `.usingDomain("game")` for multi-domain setups
 - Latest version resolution: `.toLatest()` resolves at execution time
@@ -313,26 +313,26 @@ New module providing seamless Spring Boot integration with auto-configuration, f
 - Custom DynamicOps: `.withOps(ops)` for custom serialization
 
 **Multi-Domain Support (`spring.autoconfigure`):**
-- `DataFixerRegistry` — Thread-safe registry for managing multiple DataFixer instances
+- `DataFixerRegistry` - Thread-safe registry for managing multiple DataFixer instances
 - Support for `@Qualifier` annotated bootstrap beans
 - `createQualifiedFixer()` factory method for domain-specific DataFixer creation
 - Domain availability checking via `hasDomain()` and `getAvailableDomains()`
 - Default domain ("default") for single-bootstrap setups
 
 **Actuator Integration (`spring.actuator`):**
-- `DataFixerHealthIndicator` — Reports UP/DOWN/UNKNOWN based on DataFixer operational status
-- `DataFixerInfoContributor` — Adds `aether-datafixers` section to `/actuator/info`
-- `DataFixerEndpoint` — Custom endpoint at `/actuator/datafixers` with domain details
+- `DataFixerHealthIndicator` - Reports UP/DOWN/UNKNOWN based on DataFixer operational status
+- `DataFixerInfoContributor` - Adds `aether-datafixers` section to `/actuator/info`
+- `DataFixerEndpoint` - Custom endpoint at `/actuator/datafixers` with domain details
 - Per-domain health status and version information
 - Domain-specific endpoint: `/actuator/datafixers/{domain}`
 - Fail-fast on first domain error with detailed error message
 
 **Micrometer Metrics (`spring.metrics`):**
-- `MigrationMetrics` — Records migration metrics using Micrometer
-- `aether.datafixers.migrations.success` — Counter for successful migrations (tagged by domain)
-- `aether.datafixers.migrations.failure` — Counter for failed migrations (tagged by domain, error_type)
-- `aether.datafixers.migrations.duration` — Timer for migration execution time
-- `aether.datafixers.migrations.version.span` — Distribution summary of version spans
+- `MigrationMetrics` - Records migration metrics using Micrometer
+- `aether.datafixers.migrations.success` - Counter for successful migrations (tagged by domain)
+- `aether.datafixers.migrations.failure` - Counter for failed migrations (tagged by domain, error_type)
+- `aether.datafixers.migrations.duration` - Timer for migration execution time
+- `aether.datafixers.migrations.version.span` - Distribution summary of version spans
 - Automatic metric recording in `DefaultMigrationService`
 - Thread-safe meter caching per domain
 
@@ -340,11 +340,11 @@ New module providing seamless Spring Boot integration with auto-configuration, f
 
 #### Codec Formats Documentation
 - Added new `docs/codec/` section with comprehensive format documentation
-- [Codec Overview](docs/codec/index.md) — Format comparison, package structure, dependency guide
-- [JSON Support](docs/codec/json.md) — GsonOps and JacksonJsonOps usage, examples, comparison
-- [YAML Support](docs/codec/yaml.md) — SnakeYamlOps and JacksonYamlOps usage, examples, comparison
-- [TOML Support](docs/codec/toml.md) — JacksonTomlOps usage, configuration file examples
-- [XML Support](docs/codec/xml.md) — JacksonXmlOps usage, XML-to-JsonNode mapping
+- [Codec Overview](docs/codec/index.md) - Format comparison, package structure, dependency guide
+- [JSON Support](docs/codec/json.md) - GsonOps and JacksonJsonOps usage, examples, comparison
+- [YAML Support](docs/codec/yaml.md) - SnakeYamlOps and JacksonYamlOps usage, examples, comparison
+- [TOML Support](docs/codec/toml.md) - JacksonTomlOps usage, configuration file examples
+- [XML Support](docs/codec/xml.md) - JacksonXmlOps usage, XML-to-JsonNode mapping
 - Updated [Dynamic System](docs/concepts/dynamic-system.md) with all DynamicOps implementations table
 - Updated [Codec System](docs/concepts/codec-system.md) with links to format-specific docs
 - Updated [How-To Index](docs/how-to/index.md) with Format Integration section
@@ -371,41 +371,41 @@ New module providing seamless Spring Boot integration with auto-configuration, f
 New module for schema analysis, validation, and migration coverage checking.
 
 **Schema Diffing (`schematools.diff`):**
-- `SchemaDiffer` — Fluent API for comparing two schemas
-- `SchemaDiff` — Immutable result with added/removed/common types
-- `TypeDiff` — Field-level changes for types present in both schemas
-- `FieldDiff` — Individual field change (ADDED, REMOVED, MODIFIED, UNCHANGED)
-- `DiffKind` — Enumeration of change types
+- `SchemaDiffer` - Fluent API for comparing two schemas
+- `SchemaDiff` - Immutable result with added/removed/common types
+- `TypeDiff` - Field-level changes for types present in both schemas
+- `FieldDiff` - Individual field change (ADDED, REMOVED, MODIFIED, UNCHANGED)
+- `DiffKind` - Enumeration of change types
 - Optional field-level diffing via `includeFieldLevel(true)`
 - Type filtering via `ignoreTypes(...)`
 
 **Migration Analysis (`schematools.analysis`):**
-- `MigrationAnalyzer` — Fluent API for analyzing migration paths
-- `MigrationPath` — Complete migration sequence with all steps
-- `MigrationStep` — Single version transition with optional DataFix and SchemaDiff
-- `FixCoverage` — Analysis result showing fix coverage for schema changes
-- `CoverageGap` — Represents a schema change without corresponding DataFix
+- `MigrationAnalyzer` - Fluent API for analyzing migration paths
+- `MigrationPath` - Complete migration sequence with all steps
+- `MigrationStep` - Single version transition with optional DataFix and SchemaDiff
+- `FixCoverage` - Analysis result showing fix coverage for schema changes
+- `CoverageGap` - Represents a schema change without corresponding DataFix
 - Coverage gap reasons: TYPE_ADDED, TYPE_REMOVED, TYPE_MODIFIED, FIELD_ADDED, FIELD_REMOVED, FIELD_TYPE_CHANGED
 - Orphan fix detection (fixes without schema changes)
 
 **Schema Validation (`schematools.validation`):**
-- `SchemaValidator` — Fluent API for validating schemas
-- `ValidationResult` — Immutable collection of validation issues
-- `ValidationIssue` — Single issue with severity, code, message, location, context
-- `IssueSeverity` — ERROR, WARNING, INFO levels
-- `StructureValidator` — Validates schema structure (cycles, version ordering, parent chains)
-- `ConventionChecker` — Validates naming conventions for types, fields, classes
-- `ConventionRules` — Configurable naming rules (STRICT, RELAXED, NONE, or custom)
+- `SchemaValidator` - Fluent API for validating schemas
+- `ValidationResult` - Immutable collection of validation issues
+- `ValidationIssue` - Single issue with severity, code, message, location, context
+- `IssueSeverity` - ERROR, WARNING, INFO levels
+- `StructureValidator` - Validates schema structure (cycles, version ordering, parent chains)
+- `ConventionChecker` - Validates naming conventions for types, fields, classes
+- `ConventionRules` - Configurable naming rules (STRICT, RELAXED, NONE, or custom)
 - Schema class prefix/suffix validation (e.g., "Schema" prefix for Schema100, Schema200)
 - Fix class prefix/suffix validation (e.g., "Fix" suffix for PlayerNameFix)
 - Predefined patterns for snake_case, camelCase
 - Custom validators via `customTypeValidator()` and `customFieldValidator()`
 
 **Type Introspection (`schematools.introspection`):**
-- `TypeIntrospector` — Utility for analyzing type structures
-- `TypeStructure` — Normalized, comparable representation of a Type
-- `FieldInfo` — Field metadata (name, path, optionality, type)
-- `TypeKind` — Classification (PRIMITIVE, LIST, OPTIONAL, PRODUCT, SUM, FIELD, etc.)
+- `TypeIntrospector` - Utility for analyzing type structures
+- `TypeStructure` - Normalized, comparable representation of a Type
+- `FieldInfo` - Field metadata (name, path, optionality, type)
+- `TypeKind` - Classification (PRIMITIVE, LIST, OPTIONAL, PRODUCT, SUM, FIELD, etc.)
 - Recursive field extraction with hierarchical paths
 - Structural equality comparison
 
@@ -414,9 +414,9 @@ New module for schema analysis, validation, and migration coverage checking.
 New command-line interface for data migration without writing Java code.
 
 **Commands:**
-- `migrate` — Migrate data files from one schema version to another
-- `validate` — Check if files need migration without modifying them
-- `info` — Display version info, available formats, and bootstrap details
+- `migrate` - Migrate data files from one schema version to another
+- `validate` - Check if files need migration without modifying them
+- `info` - Display version info, available formats, and bootstrap details
 
 **Core Features:**
 - Batch processing of multiple files with shell glob expansion
@@ -430,21 +430,21 @@ New command-line interface for data migration without writing Java code.
 - CI/CD friendly exit codes (0=success, 1=error, 2=migration needed)
 
 **Format Handler System:**
-- `FormatHandler<T>` — SPI for pluggable serialization formats
-- `FormatRegistry` — ServiceLoader-based handler discovery
-- `json-gson` — JSON format using Google Gson (default)
-- `json-jackson` — JSON format using Jackson Databind
+- `FormatHandler<T>` - SPI for pluggable serialization formats
+- `FormatRegistry` - ServiceLoader-based handler discovery
+- `json-gson` - JSON format using Google Gson (default)
+- `json-jackson` - JSON format using Jackson Databind
 
 **Utilities:**
-- `BootstrapLoader` — Reflective loading of DataFixerBootstrap implementations
-- `VersionExtractor` — Extract version from nested JSON paths (dot notation)
-- `ReportFormatter` — Text and JSON migration report formatting
-- `TextReportFormatter` — Human-readable single-line reports
-- `JsonReportFormatter` — Machine-readable JSON reports
+- `BootstrapLoader` - Reflective loading of DataFixerBootstrap implementations
+- `VersionExtractor` - Extract version from nested JSON paths (dot notation)
+- `ReportFormatter` - Text and JSON migration report formatting
+- `TextReportFormatter` - Human-readable single-line reports
+- `JsonReportFormatter` - Machine-readable JSON reports
 
 **Exceptions:**
-- `BootstrapLoadException` — Bootstrap class loading failures
-- `FormatParseException` — Input parsing failures
+- `BootstrapLoadException` - Bootstrap class loading failures
+- `FormatParseException` - Input parsing failures
 
 ### Documentation
 
@@ -460,44 +460,44 @@ New command-line interface for data migration without writing Java code.
 ### Added
 
 #### Testkit Module (`aether-datafixers-testkit`)
-- **TestData** — Fluent builders for creating test data (`TestData.gson().object()...`)
-- **AetherAssertions** — Custom AssertJ assertions for `Dynamic`, `DataResult`, `Typed`
-- **DataFixTester** — Test harness for isolated DataFix testing with fluent API
-- **MigrationTester** — Test harness for full migration chain testing
-- **SchemaTester** — Test harness for schema validation
-- **QuickFix** — Factory methods for common fix patterns (rename, add, remove, transform)
-- **MockSchemas** — Mock schema utilities for testing
-- **RecordingContext** — Context that records warnings for test verification
+- **TestData** - Fluent builders for creating test data (`TestData.gson().object()...`)
+- **AetherAssertions** - Custom AssertJ assertions for `Dynamic`, `DataResult`, `Typed`
+- **DataFixTester** - Test harness for isolated DataFix testing with fluent API
+- **MigrationTester** - Test harness for full migration chain testing
+- **SchemaTester** - Test harness for schema validation
+- **QuickFix** - Factory methods for common fix patterns (rename, add, remove, transform)
+- **MockSchemas** - Mock schema utilities for testing
+- **RecordingContext** - Context that records warnings for test verification
 
 #### Migration Diagnostics
-- **DiagnosticContext** — Opt-in diagnostic context for capturing migration reports
-- **DiagnosticOptions** — Configurable options (snapshots, rule details, pretty print)
-- **MigrationReport** — Structured report with timing, applied fixes, and touched types
-- **FixExecution** — Per-fix execution details with before/after snapshots
-- **RuleApplication** — Per-rule application details
+- **DiagnosticContext** - Opt-in diagnostic context for capturing migration reports
+- **DiagnosticOptions** - Configurable options (snapshots, rule details, pretty print)
+- **MigrationReport** - Structured report with timing, applied fixes, and touched types
+- **FixExecution** - Per-fix execution details with before/after snapshots
+- **RuleApplication** - Per-rule application details
 
 #### Extended Rewrite Rules
-- `Rules.renameFields(ops, map)` — Batch rename multiple fields
-- `Rules.removeFields(ops, fields...)` — Batch remove multiple fields
-- `Rules.groupFields(ops, target, fields...)` — Group flat fields into nested object
-- `Rules.flattenField(ops, field)` — Flatten nested object to root level
-- `Rules.moveField(ops, source, target)` — Move field between paths
-- `Rules.copyField(ops, source, target)` — Copy field to new location
-- `Rules.transformFieldAt(ops, path, fn)` — Transform at nested path
-- `Rules.renameFieldAt(ops, path, newName)` — Rename at nested path
-- `Rules.removeFieldAt(ops, path)` — Remove at nested path
-- `Rules.addFieldAt(ops, path, value)` — Add at nested path
-- `Rules.ifFieldExists(ops, field, rule)` — Conditional on field existence
-- `Rules.ifFieldMissing(ops, field, rule)` — Conditional on field absence
-- `Rules.ifFieldEquals(ops, field, value, rule)` — Conditional on field value
+- `Rules.renameFields(ops, map)` - Batch rename multiple fields
+- `Rules.removeFields(ops, fields...)` - Batch remove multiple fields
+- `Rules.groupFields(ops, target, fields...)` - Group flat fields into nested object
+- `Rules.flattenField(ops, field)` - Flatten nested object to root level
+- `Rules.moveField(ops, source, target)` - Move field between paths
+- `Rules.copyField(ops, source, target)` - Copy field to new location
+- `Rules.transformFieldAt(ops, path, fn)` - Transform at nested path
+- `Rules.renameFieldAt(ops, path, newName)` - Rename at nested path
+- `Rules.removeFieldAt(ops, path)` - Remove at nested path
+- `Rules.addFieldAt(ops, path, value)` - Add at nested path
+- `Rules.ifFieldExists(ops, field, rule)` - Conditional on field existence
+- `Rules.ifFieldMissing(ops, field, rule)` - Conditional on field absence
+- `Rules.ifFieldEquals(ops, field, value, rule)` - Conditional on field value
 
 #### High-Performance APIs
-- **BatchTransform** — Builder for batching multiple field operations
-- `Rules.batch(ops, builder)` — Apply multiple operations in single encode/decode cycle
-- `Rules.conditionalTransform(ops, predicate, transform)` — Single-pass conditional transform
-- `Rules.ifFieldExists(ops, field, transform)` — Single-pass version (Function overload)
-- `Rules.ifFieldMissing(ops, field, transform)` — Single-pass version (Function overload)
-- `Rules.ifFieldEquals(ops, field, value, transform)` — Single-pass version (Function overload)
+- **BatchTransform** - Builder for batching multiple field operations
+- `Rules.batch(ops, builder)` - Apply multiple operations in single encode/decode cycle
+- `Rules.conditionalTransform(ops, predicate, transform)` - Single-pass conditional transform
+- `Rules.ifFieldExists(ops, field, transform)` - Single-pass version (Function overload)
+- `Rules.ifFieldMissing(ops, field, transform)` - Single-pass version (Function overload)
+- `Rules.ifFieldEquals(ops, field, value, transform)` - Single-pass version (Function overload)
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This project follows a **Git Flow**-inspired branching model with two long-lived
 
 | Branch    | Purpose                                                                                                                                                                                              |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `main`    | 🔒 **Production-ready code only.** Represents the latest stable release. Direct commits and PRs from feature/fix branches are **not allowed** — only `release/*` branches may be merged into `main`. |
+| `main`    | 🔒 **Production-ready code only.** Represents the latest stable release. Direct commits and PRs from feature/fix branches are **not allowed** - only `release/*` branches may be merged into `main`. |
 | `develop` | 🔧 **Integration branch.** All feature and fix contributions are merged here. This is the **default target** for your PRs.                                                                           |
 
 ### Short-Lived Branches
@@ -64,8 +64,8 @@ git checkout -b feature/new-awesome-feature
 ```
 
 Use a meaningful branch name with the appropriate prefix:
-- `feature/` — for new features (e.g., `feature/optic-integration`)
-- `bugfix/` — for bug fixes (e.g., `bugfix/builder-null-pointer`)
+- `feature/` - for new features (e.g., `feature/optic-integration`)
+- `bugfix/` - for bug fixes (e.g., `bugfix/builder-null-pointer`)
 
 ### 3️⃣ Implement Your Changes
 - Follow the coding style of the project.
@@ -115,7 +115,7 @@ This adds a `Signed-off-by: Your Name <your.email@example.com>` line to your com
 
 ## 🤖 AI-Assisted Contributions
 
-We allow AI-assisted contributions under strict conditions. If you use AI tools (GitHub Copilot, Claude, ChatGPT, etc.), you **must** follow our [AI Usage Guidelines](AI_USAGE.md) — including mandatory disclosure and quality standards.
+We allow AI-assisted contributions under strict conditions. If you use AI tools (GitHub Copilot, Claude, ChatGPT, etc.), you **must** follow our [AI Usage Guidelines](AI_USAGE.md) - including mandatory disclosure and quality standards.
 
 ---
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@ This file lists contributors who joined the project in each release version.
 
 | New Contributor         | Contribution |
 |-------------------------|--------------|
-| *(No new contributors)* | —            |
+| *(No new contributors)* | -            |
 
 ---
 
@@ -28,7 +28,7 @@ This file lists contributors who joined the project in each release version.
 
 | New Contributor         | Contribution |
 |-------------------------|--------------|
-| *(No new contributors)* | —            |
+| *(No new contributors)* | -            |
 
 ---
 
@@ -36,7 +36,7 @@ This file lists contributors who joined the project in each release version.
 
 | New Contributor         | Contribution |
 |-------------------------|--------------|
-| *(No new contributors)* | —            |
+| *(No new contributors)* | -            |
 
 ---
 
@@ -44,7 +44,7 @@ This file lists contributors who joined the project in each release version.
 
 | New Contributor         | Contribution |
 |-------------------------|--------------|
-| *(No new contributors)* | —            |
+| *(No new contributors)* | -            |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Aether Datafixers is a data migration framework that enables **forward patching** of serialized data through versioned schema definitions and composable fixers. It is inspired by Minecraft's [DataFixer Upper (DFU)](docs/appendix/comparison-with-dfu.md) but designed from the ground up for **simplicity**, **clarity**, and **ease of use**.
 
-The framework is **format-agnostic** — it works with JSON, YAML, TOML, XML, or any custom serialization format through the `Dynamic<T>` and `DynamicOps<T>` abstraction layer. All core types are **immutable and thread-safe**, making Aether Datafixers suitable for concurrent, high-throughput environments. The modular architecture lets you pick exactly what you need: just the core, or add the CLI, Spring Boot integration, testkit, schema analysis tools, and more.
+The framework is **format-agnostic** - it works with JSON, YAML, TOML, XML, or any custom serialization format through the `Dynamic<T>` and `DynamicOps<T>` abstraction layer. All core types are **immutable and thread-safe**, making Aether Datafixers suitable for concurrent, high-throughput environments. The modular architecture lets you pick exactly what you need: just the core, or add the CLI, Spring Boot integration, testkit, schema analysis tools, and more.
 
 ## 📋 Table of Contents
 
@@ -207,7 +207,7 @@ dependencies {
 | **TypeReference**   | String-based key for routing data to the correct fixes (e.g., `"player"`, `"entity"`) |
 | **Schema**          | Associates a `DataVersion` with a `TypeRegistry` defining the types at that version   |
 | **DataFix**         | A transformation that migrates data from one version to another                       |
-| **Dynamic\<T\>**    | Format-agnostic data wrapper — manipulate data without knowing the underlying format  |
+| **Dynamic\<T\>**    | Format-agnostic data wrapper - manipulate data without knowing the underlying format  |
 | **DynamicOps\<T\>** | Operations interface for a specific format (Gson, Jackson, SnakeYAML, etc.)           |
 | **Codec**           | Bidirectional transformation between typed Java objects and `Dynamic` representations |
 | **TypeRewriteRule** | Composable rule defining how data is rewritten during a fix                           |
@@ -220,11 +220,11 @@ dependencies {
 |------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | [**aether-datafixers-api**](aether-datafixers-api)                                 | Core interfaces and API contracts                                                                       |
 | [**aether-datafixers-core**](aether-datafixers-core)                               | Default implementations of the API interfaces                                                           |
-| [**aether-datafixers-codec**](aether-datafixers-codec)                             | Multi-format DynamicOps — JSON (Gson, Jackson), YAML (SnakeYAML, Jackson), TOML, XML                    |
-| [**aether-datafixers-testkit**](aether-datafixers-testkit)                         | Fluent test builders, AssertJ assertions, DataFix test harnesses — [docs](docs/testkit/index.md)        |
-| [**aether-datafixers-cli**](aether-datafixers-cli)                                 | Command-line migration and validation tool — [docs](docs/cli/index.md)                                  |
-| [**aether-datafixers-schema-tools**](aether-datafixers-schema-tools)               | Schema diffing, validation, migration analysis — [docs](docs/schema-tools/index.md)                     |
-| [**aether-datafixers-spring-boot-starter**](aether-datafixers-spring-boot-starter) | Spring Boot 3.x auto-config, MigrationService, Actuator, Micrometer — [docs](docs/spring-boot/index.md) |
+| [**aether-datafixers-codec**](aether-datafixers-codec)                             | Multi-format DynamicOps - JSON (Gson, Jackson), YAML (SnakeYAML, Jackson), TOML, XML                    |
+| [**aether-datafixers-testkit**](aether-datafixers-testkit)                         | Fluent test builders, AssertJ assertions, DataFix test harnesses - [docs](docs/testkit/index.md)        |
+| [**aether-datafixers-cli**](aether-datafixers-cli)                                 | Command-line migration and validation tool - [docs](docs/cli/index.md)                                  |
+| [**aether-datafixers-schema-tools**](aether-datafixers-schema-tools)               | Schema diffing, validation, migration analysis - [docs](docs/schema-tools/index.md)                     |
+| [**aether-datafixers-spring-boot-starter**](aether-datafixers-spring-boot-starter) | Spring Boot 3.x auto-config, MigrationService, Actuator, Micrometer - [docs](docs/spring-boot/index.md) |
 | [**aether-datafixers-examples**](aether-datafixers-examples)                       | Runnable usage examples demonstrating real-world patterns                                               |
 | [**aether-datafixers-bom**](aether-datafixers-bom)                                 | Bill of Materials for coordinated version management                                                    |
 | [**aether-datafixers-benchmarks**](aether-datafixers-benchmarks)                   | JMH microbenchmarks for performance validation                                                          |
@@ -248,7 +248,7 @@ Each DataFix transforms Dynamic<T> using composable TypeRewriteRules
 Output: migrated Dynamic<T> at the target version
 ```
 
-The framework handles version ordering, type routing, and rule composition automatically. You define schemas and fixes — Aether Datafixers handles the rest.
+The framework handles version ordering, type routing, and rule composition automatically. You define schemas and fixes - Aether Datafixers handles the rest.
 
 ## 💡 Code Examples
 
@@ -510,7 +510,7 @@ Person moved = cityLens.set(alice, "Seattle");  // Alice now in Seattle
 | [Tutorials](docs/tutorials/index.md) | Step-by-step guides for common scenarios |
 | [How-To Guides](docs/how-to/index.md) | Focused guides for specific operations (rename, add, remove, transform, batch, ...) |
 | [Advanced Topics](docs/advanced/custom-optics.md) | Custom optics, concurrent migrations, recursive types, traversal strategies |
-| [Codec Formats](docs/codec/index.md) | JSON, YAML, TOML, XML — format comparison and usage |
+| [Codec Formats](docs/codec/index.md) | JSON, YAML, TOML, XML - format comparison and usage |
 | [CLI](docs/cli/index.md) | Commands, format handlers, usage examples |
 | [Schema Tools](docs/schema-tools/index.md) | Diffing, migration analysis, validation, introspection |
 | [Spring Boot](docs/spring-boot/index.md) | Auto-configuration, MigrationService, Actuator, Metrics |
@@ -544,7 +544,7 @@ java -jar aether-datafixers-benchmarks/target/benchmarks.jar
 
 ## 🤝 Contributing
 
-We welcome contributions of all kinds — bug fixes, features, documentation improvements, and discussions.
+We welcome contributions of all kinds - bug fixes, features, documentation improvements, and discussions.
 
 Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a pull request. This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). For AI-assisted contributions, please review our [AI Usage Guidelines](AI_USAGE.md).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# 🚀 **Aether Datafixers v0.5.0 — API Freeze & Release Readiness**
+# 🚀 **Aether Datafixers v0.5.0 - API Freeze & Release Readiness**
 
 The API freeze release with stabilized public interfaces, comprehensive validation tooling, extended codec support, and full multi-format integration across all modules.
 
@@ -6,19 +6,19 @@ The API freeze release with stabilized public interfaces, comprehensive validati
 
 ## 🎯 Highlights in v0.5.0
 
-- ✅ **API Freeze** — Public API is now stable; no breaking changes expected before v1.0.0
-- ✅ **Schema Validation Integration** — Full `MigrationAnalyzer` integration for fix coverage validation
-- ✅ **MigrationService.withOps()** — Custom `DynamicOps` support for format conversion during migrations
-- ✅ **Extended Codec Support** — Multi-format DynamicOps integration for CLI, Testkit and Spring Boot modules
-- ✅ **Functional Tests Module** — New `aether-datafixers-functional-tests` with E2E and integration tests
-- ✅ **Comprehensive Documentation** — Complete documentation suite covering all modules and features
+- ✅ **API Freeze** - Public API is now stable; no breaking changes expected before v1.0.0
+- ✅ **Schema Validation Integration** - Full `MigrationAnalyzer` integration for fix coverage validation
+- ✅ **MigrationService.withOps()** - Custom `DynamicOps` support for format conversion during migrations
+- ✅ **Extended Codec Support** - Multi-format DynamicOps integration for CLI, Testkit and Spring Boot modules
+- ✅ **Functional Tests Module** - New `aether-datafixers-functional-tests` with E2E and integration tests
+- ✅ **Comprehensive Documentation** - Complete documentation suite covering all modules and features
 
 ---
 
 ## 📦 Installation
 
 > [!TIP]
-> All Aether artifacts are available on **Maven Central** — no extra repository required.
+> All Aether artifacts are available on **Maven Central** - no extra repository required.
 
 ### Maven
 
@@ -204,9 +204,9 @@ mvn verify -Pit
 
 **Deprecations (removal planned for v1.0.0)**
 
-- `de.splatgames.aether.datafixers.codec.gson.GsonOps` — Use `codec.json.gson.GsonOps`
-- `de.splatgames.aether.datafixers.codec.jackson.JacksonOps` — Use `codec.json.jackson.JacksonJsonOps` for JSON, or the format-specific classes (`JacksonYamlOps`, `JacksonTomlOps`, `JacksonXmlOps`)
-- `TestData.jackson()` — Use `TestData.jacksonJson()` instead
+- `de.splatgames.aether.datafixers.codec.gson.GsonOps` - Use `codec.json.gson.GsonOps`
+- `de.splatgames.aether.datafixers.codec.jackson.JacksonOps` - Use `codec.json.jackson.JacksonJsonOps` for JSON, or the format-specific classes (`JacksonYamlOps`, `JacksonTomlOps`, `JacksonXmlOps`)
+- `TestData.jackson()` - Use `TestData.jacksonJson()` instead
 
 **Full Changelog:** [v0.4.0...v0.5.0](https://github.com/aether-framework/aether-datafixers/compare/v0.4.0...v0.5.0)
 
@@ -236,12 +236,12 @@ import de.splatgames.aether.datafixers.codec.json.gson.GsonOps;
 
 ### v1.0.0 (next)
 
-- **Stable Release** — Production-ready with semantic versioning guarantees
-- **Performance Benchmarks** — Published benchmark suite
-- **Extended Documentation** — Video tutorials and cookbook examples
+- **Stable Release** - Production-ready with semantic versioning guarantees
+- **Performance Benchmarks** - Published benchmark suite
+- **Extended Documentation** - Video tutorials and cookbook examples
 
 ---
 
 ## 📜 License
 
-**MIT** — see `LICENSE`.
+**MIT** - see `LICENSE`.

--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Affine.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Affine.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
  *
  * <p>An {@code Affine} is the generalization of both {@link Lens} and {@link Prism}. Like a lens,
  * it can set values within a structure. Like a prism, the focus may not exist. This makes affines ideal for optional
- * fields within product types—fields that might be present but aren't guaranteed.</p>
+ * fields within product types-fields that might be present but aren't guaranteed.</p>
  *
  * <h2>When to Use an Affine</h2>
  * <p>Use an affine when you need to:</p>

--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Finder.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Finder.java
@@ -197,11 +197,11 @@ public interface Finder<A> {
      * Dynamic<?> updated = firstScoreFinder.set(data, data.createInt(100));
      * // updated: {"scores": [100, 92, 78]}
      *
-     * // Out-of-range (positive) index — get returns null, set returns root unchanged
+     * // Out-of-range (positive) index - get returns null, set returns root unchanged
      * Finder<?> outOfBounds = scoresFinder.then(Finder.index(10));
      * Dynamic<?> missing = outOfBounds.get(data);  // null
      *
-     * // Negative index — throws IllegalArgumentException immediately
+     * // Negative index - throws IllegalArgumentException immediately
      * Finder.index(-1);  // throws IllegalArgumentException
      * }</pre>
      *
@@ -259,7 +259,7 @@ public interface Finder<A> {
     /**
      * Creates an identity finder that focuses on the root dynamic value itself.
      *
-     * <p>The identity finder is the simplest possible finder—it returns the entire
+     * <p>The identity finder is the simplest possible finder-it returns the entire
      * root as its focus and replaces the entire root when set. This is useful as a starting point for composition or as
      * a neutral element in finder chains.</p>
      *

--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Getter.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Getter.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
  * A getter is a read-only optic that extracts a value from a source without modification capability.
  *
  * <p>A {@code Getter} represents the most basic form of optic: a simple function from a
- * source type to a focus type. Unlike a {@link Lens}, a getter provides no way to modify the source—it is purely for
+ * source type to a focus type. Unlike a {@link Lens}, a getter provides no way to modify the source-it is purely for
  * extraction. This makes getters ideal when you want to explicitly communicate that a transformation is one-way and
  * read-only.</p>
  *

--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Iso.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/optic/Iso.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
  *
  * <p>An {@code Iso} (isomorphism) is the most powerful optic, representing a 1-to-1
  * correspondence between two types. It can convert from S to A and back to S without any loss of information. Because
- * of this bidirectional nature, an iso is simultaneously both a {@link Lens} and a {@link Prism}—it can be used
+ * of this bidirectional nature, an iso is simultaneously both a {@link Lens} and a {@link Prism}-it can be used
  * anywhere either is expected.</p>
  *
  * <h2>When to Use an Iso</h2>

--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/type/template/TypeFamily.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/type/template/TypeFamily.java
@@ -179,7 +179,7 @@ public interface TypeFamily {
      * structures.</p>
      *
      * <p><strong>Important:</strong> The self-reference family must not be accessed
-     * during the definition function's initial call—it's only valid after the definition returns. Accessing index 0
+     * during the definition function's initial call-it's only valid after the definition returns. Accessing index 0
      * before initialization throws an exception.</p>
      *
      * <h4>Example</h4>

--- a/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/type/template/TypeTemplate.java
+++ b/aether-datafixers-api/src/main/java/de/splatgames/aether/datafixers/api/type/template/TypeTemplate.java
@@ -162,7 +162,7 @@ public interface TypeTemplate {
      * {@code "name=originalDescription"}. This is primarily useful for debugging and logging, making it easier to
      * identify templates in error messages.</p>
      *
-     * <p>The template's behavior is unchanged—only its {@link #describe()} output
+     * <p>The template's behavior is unchanged-only its {@link #describe()} output
      * is affected.</p>
      *
      * <h4>Example</h4>

--- a/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/format/FormatHandler.java
+++ b/aether-datafixers-cli/src/main/java/de/splatgames/aether/datafixers/cli/format/FormatHandler.java
@@ -33,12 +33,12 @@ import org.jetbrains.annotations.NotNull;
  *
  * <h2>Built-in Format Handlers</h2>
  * <ul>
- *   <li>{@code json-gson} — JSON format using Google Gson</li>
- *   <li>{@code json-jackson} — JSON format using Jackson Databind</li>
- *   <li>{@code yaml-snakeyaml} — YAML format using SnakeYAML</li>
- *   <li>{@code yaml-jackson} — YAML format using Jackson YAML</li>
- *   <li>{@code toml-jackson} — TOML format using Jackson TOML</li>
- *   <li>{@code xml-jackson} — XML format using Jackson XML</li>
+ *   <li>{@code json-gson} - JSON format using Google Gson</li>
+ *   <li>{@code json-jackson} - JSON format using Jackson Databind</li>
+ *   <li>{@code yaml-snakeyaml} - YAML format using SnakeYAML</li>
+ *   <li>{@code yaml-jackson} - YAML format using Jackson YAML</li>
+ *   <li>{@code toml-jackson} - TOML format using Jackson TOML</li>
+ *   <li>{@code xml-jackson} - XML format using Jackson XML</li>
  * </ul>
  *
  * <h2>Implementing a Custom Format Handler</h2>

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,14 +8,14 @@ Aether Datafixers is a framework for migrating serialized data through schema ve
 
 ### Key Features
 
-- **Schema-Based Versioning** — Define data types per version with `Schema` and `TypeRegistry`
-- **Forward Patching** — Apply `DataFix` instances sequentially to migrate data across versions
-- **Format-Agnostic** — Work with any serialization format via `Dynamic<T>` and `DynamicOps<T>`
-- **Codec System** — Bidirectional transformation between typed Java objects and dynamic representations
-- **Profunctor Optics** — Composable, type-safe accessors for nested data (`Lens`, `Prism`, `Finder`)
-- **Type Safety** — Strong typing with `TypeReference` identifiers for data routing
-- **Migration Diagnostics** — Opt-in structured reports with timing, rules, and snapshots
-- **JDK 17+** — Built and tested on modern LTS JVMs
+- **Schema-Based Versioning** - Define data types per version with `Schema` and `TypeRegistry`
+- **Forward Patching** - Apply `DataFix` instances sequentially to migrate data across versions
+- **Format-Agnostic** - Work with any serialization format via `Dynamic<T>` and `DynamicOps<T>`
+- **Codec System** - Bidirectional transformation between typed Java objects and dynamic representations
+- **Profunctor Optics** - Composable, type-safe accessors for nested data (`Lens`, `Prism`, `Finder`)
+- **Type Safety** - Strong typing with `TypeReference` identifiers for data routing
+- **Migration Diagnostics** - Opt-in structured reports with timing, rules, and snapshots
+- **JDK 17+** - Built and tested on modern LTS JVMs
 
 ---
 
@@ -25,32 +25,32 @@ Aether Datafixers is a framework for migrating serialized data through schema ve
 
 New to Aether Datafixers? Start here:
 
-- [Installation](getting-started/installation.md) — Add the framework to your project
-- [Quick Start](getting-started/quick-start.md) — Get up and running in 5 minutes
-- [Your First Migration](getting-started/your-first-migration.md) — Complete tutorial for beginners
+- [Installation](getting-started/installation.md) - Add the framework to your project
+- [Quick Start](getting-started/quick-start.md) - Get up and running in 5 minutes
+- [Your First Migration](getting-started/your-first-migration.md) - Complete tutorial for beginners
 
 ### Core Concepts
 
 Understand the fundamental concepts:
 
-- [Architecture Overview](concepts/architecture-overview.md) — How the framework fits together
-- [DataVersion](concepts/data-version.md) — Version identifiers for data schemas
-- [TypeReference](concepts/type-reference.md) — Type identifiers for data routing
-- [Schema System](concepts/schema-system.md) — Defining data structures per version
-- [DataFix System](concepts/datafix-system.md) — Creating and applying migrations
-- [Dynamic System](concepts/dynamic-system.md) — Format-agnostic data manipulation
-- [Codec System](concepts/codec-system.md) — Encoding and decoding typed data
-- [Optics](concepts/optics/index.md) — Composable data accessors
+- [Architecture Overview](concepts/architecture-overview.md) - How the framework fits together
+- [DataVersion](concepts/data-version.md) - Version identifiers for data schemas
+- [TypeReference](concepts/type-reference.md) - Type identifiers for data routing
+- [Schema System](concepts/schema-system.md) - Defining data structures per version
+- [DataFix System](concepts/datafix-system.md) - Creating and applying migrations
+- [Dynamic System](concepts/dynamic-system.md) - Format-agnostic data manipulation
+- [Codec System](concepts/codec-system.md) - Encoding and decoding typed data
+- [Optics](concepts/optics/index.md) - Composable data accessors
 
 ### Tutorials
 
 Step-by-step learning guides:
 
-- [Basic Migration](tutorials/basic-migration.md) — Your first complete migration
-- [Multi-Version Migration](tutorials/multi-version-migration.md) — Chaining migrations
-- [Using Codecs](tutorials/using-codecs.md) — Building custom codecs
-- [RecordCodecBuilder](tutorials/record-codec-builder.md) — Composing record codecs
-- [Nested Transformations](tutorials/nested-transformations.md) — Restructuring data
+- [Basic Migration](tutorials/basic-migration.md) - Your first complete migration
+- [Multi-Version Migration](tutorials/multi-version-migration.md) - Chaining migrations
+- [Using Codecs](tutorials/using-codecs.md) - Building custom codecs
+- [RecordCodecBuilder](tutorials/record-codec-builder.md) - Composing record codecs
+- [Nested Transformations](tutorials/nested-transformations.md) - Restructuring data
 
 ### How-To Guides
 
@@ -69,50 +69,50 @@ Practical task-oriented guides:
 
 DynamicOps implementations for various data formats:
 
-- [Codec Overview](codec/index.md) — Introduction to DynamicOps implementations
-- [JSON Support](codec/json.md) — GsonOps and JacksonJsonOps
-- [YAML Support](codec/yaml.md) — SnakeYamlOps and JacksonYamlOps
-- [TOML Support](codec/toml.md) — JacksonTomlOps
-- [XML Support](codec/xml.md) — JacksonXmlOps
+- [Codec Overview](codec/index.md) - Introduction to DynamicOps implementations
+- [JSON Support](codec/json.md) - GsonOps and JacksonJsonOps
+- [YAML Support](codec/yaml.md) - SnakeYamlOps and JacksonYamlOps
+- [TOML Support](codec/toml.md) - JacksonTomlOps
+- [XML Support](codec/xml.md) - JacksonXmlOps
 
 ### Examples
 
 Working code examples:
 
-- [Game Data Example](examples/game-data-example/index.md) — Complete game save migration
-- [User Profile Example](examples/user-profile-example.md) — User data migration
-- [Configuration Example](examples/configuration-example.md) — Config file versioning
+- [Game Data Example](examples/game-data-example/index.md) - Complete game save migration
+- [User Profile Example](examples/user-profile-example.md) - User data migration
+- [Configuration Example](examples/configuration-example.md) - Config file versioning
 
 ### Testing
 
 Test your DataFixes and migrations with the Testkit module:
 
-- [Testkit Overview](testkit/index.md) — Introduction to the testing utilities
-- [Test Data Builders](testkit/test-data-builders.md) — Fluent API for creating test data
-- [Custom Assertions](testkit/assertions.md) — AssertJ assertions for Dynamic, DataResult, Typed
-- [DataFixTester](testkit/datafix-tester.md) — Test harness for isolated DataFix testing
-- [QuickFix Factories](testkit/quick-fix.md) — Factory methods for common fix patterns
-- [Mock Schemas](testkit/mock-schemas.md) — Mock schema utilities
+- [Testkit Overview](testkit/index.md) - Introduction to the testing utilities
+- [Test Data Builders](testkit/test-data-builders.md) - Fluent API for creating test data
+- [Custom Assertions](testkit/assertions.md) - AssertJ assertions for Dynamic, DataResult, Typed
+- [DataFixTester](testkit/datafix-tester.md) - Test harness for isolated DataFix testing
+- [QuickFix Factories](testkit/quick-fix.md) - Factory methods for common fix patterns
+- [Mock Schemas](testkit/mock-schemas.md) - Mock schema utilities
 
 ### Command-Line Interface
 
 Migrate and validate data files from the command line:
 
-- [CLI Overview](cli/index.md) — Introduction to the CLI tool
-- [Installation](cli/installation.md) — Building and running the CLI
-- [Command Reference](cli/commands.md) — Detailed command documentation
-- [Format Handlers](cli/format-handlers.md) — Custom format handler development
-- [Examples](cli/examples.md) — Practical usage examples
+- [CLI Overview](cli/index.md) - Introduction to the CLI tool
+- [Installation](cli/installation.md) - Building and running the CLI
+- [Command Reference](cli/commands.md) - Detailed command documentation
+- [Format Handlers](cli/format-handlers.md) - Custom format handler development
+- [Examples](cli/examples.md) - Practical usage examples
 
 ### Schema Tools
 
 Analyze, compare, and validate your schemas:
 
-- [Schema Tools Overview](schema-tools/index.md) — Introduction to schema tooling
-- [Schema Diffing](schema-tools/schema-diffing.md) — Compare schemas and detect changes
-- [Migration Analysis](schema-tools/migration-analysis.md) — Analyze migration paths and fix coverage
-- [Schema Validation](schema-tools/schema-validation.md) — Validate structure and conventions
-- [Type Introspection](schema-tools/type-introspection.md) — Inspect type structures
+- [Schema Tools Overview](schema-tools/index.md) - Introduction to schema tooling
+- [Schema Diffing](schema-tools/schema-diffing.md) - Compare schemas and detect changes
+- [Migration Analysis](schema-tools/migration-analysis.md) - Analyze migration paths and fix coverage
+- [Schema Validation](schema-tools/schema-validation.md) - Validate structure and conventions
+- [Type Introspection](schema-tools/type-introspection.md) - Inspect type structures
 
 ### Advanced Topics
 
@@ -120,30 +120,30 @@ For experienced users:
 
 - [Traversal Strategies](advanced/traversal-strategies.md)
 - [Custom Optics](advanced/custom-optics.md)
-- [Performance Optimization](advanced/performance-optimization.md) — Benchmark results, format comparison, and tuning
+- [Performance Optimization](advanced/performance-optimization.md) - Benchmark results, format comparison, and tuning
 - [Extending the Framework](advanced/extending-framework.md)
 
 ### Security
 
 Guidance for processing untrusted data safely:
 
-- [Security Overview](security/index.md) — Introduction to security considerations
-- [Threat Model](security/threat-model.md) — Attack vectors and trust boundaries
-- [Format Security](security/format-considerations/index.md) — Per-format security guidance
-- [Best Practices](security/best-practices.md) — Secure configuration patterns
-- [Secure Configuration Examples](security/secure-configuration-examples.md) — Ready-to-use examples
+- [Security Overview](security/index.md) - Introduction to security considerations
+- [Threat Model](security/threat-model.md) - Attack vectors and trust boundaries
+- [Format Security](security/format-considerations/index.md) - Per-format security guidance
+- [Best Practices](security/best-practices.md) - Secure configuration patterns
+- [Secure Configuration Examples](security/secure-configuration-examples.md) - Ready-to-use examples
 
 ### Spring Boot Integration
 
 Seamlessly integrate Aether Datafixers into Spring Boot applications:
 
-- [Spring Boot Overview](spring-boot/index.md) — Introduction to the Spring Boot starter
-- [Quick Start](spring-boot/getting-started.md) — Add the starter and run your first migration
-- [Configuration Reference](spring-boot/configuration.md) — All configuration properties
-- [MigrationService API](spring-boot/migration-service.md) — Fluent migration API
-- [Multi-Domain Setup](spring-boot/multi-domain.md) — Managing multiple DataFixer instances
-- [Actuator Integration](spring-boot/actuator.md) — Health indicators and endpoints
-- [Metrics Integration](spring-boot/metrics.md) — Micrometer metrics for observability
+- [Spring Boot Overview](spring-boot/index.md) - Introduction to the Spring Boot starter
+- [Quick Start](spring-boot/getting-started.md) - Add the starter and run your first migration
+- [Configuration Reference](spring-boot/configuration.md) - All configuration properties
+- [MigrationService API](spring-boot/migration-service.md) - Fluent migration API
+- [Multi-Domain Setup](spring-boot/multi-domain.md) - Managing multiple DataFixer instances
+- [Actuator Integration](spring-boot/actuator.md) - Health indicators and endpoints
+- [Metrics Integration](spring-boot/metrics.md) - Micrometer metrics for observability
 
 ### Support
 

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -4,13 +4,13 @@ Advanced concepts and techniques for Aether Datafixers.
 
 ## Topics
 
-- [Traversal Strategies](traversal-strategies.md) — TopDown, BottomUp, Everywhere
-- [Custom Optics](custom-optics.md) — Creating custom optic implementations
-- [Recursive Types](recursive-types.md) — Handling recursive data structures
-- [Performance Optimization](performance-optimization.md) — Benchmark results, format comparison, and tuning
-- [Concurrent Migrations](concurrent-migrations.md) — Thread-safe patterns
-- [Format Conversion](format-conversion.md) — Cross-format data conversion
-- [Extending the Framework](extending-framework.md) — Adding custom functionality
+- [Traversal Strategies](traversal-strategies.md) - TopDown, BottomUp, Everywhere
+- [Custom Optics](custom-optics.md) - Creating custom optic implementations
+- [Recursive Types](recursive-types.md) - Handling recursive data structures
+- [Performance Optimization](performance-optimization.md) - Benchmark results, format comparison, and tuning
+- [Concurrent Migrations](concurrent-migrations.md) - Thread-safe patterns
+- [Format Conversion](format-conversion.md) - Cross-format data conversion
+- [Extending the Framework](extending-framework.md) - Adding custom functionality
 
 ## Prerequisites
 

--- a/docs/advanced/performance-optimization.md
+++ b/docs/advanced/performance-optimization.md
@@ -44,14 +44,14 @@ Measures the cost of applying one `DataFix` to a `Dynamic` value.
 | singleRenameFix       | SMALL    |                3.633 |             0.281 |
 | singleRenameFix       | MEDIUM   |                3.376 |             0.300 |
 | singleRenameFix       | LARGE    |                3.233 |             0.311 |
-| playerDataFix         | —        |                0.109 |             9.147 |
-| playerDataFixEndToEnd | —        |                0.032 |            31.194 |
+| playerDataFix         | -        |                0.109 |             9.147 |
+| playerDataFixEndToEnd | -        |                0.032 |            31.194 |
 
 **Key takeaways:**
 
 - **Framework overhead is ~0.25 µs** per fix invocation (identity fix baseline).
 - A simple rename adds only ~0.03–0.06 µs on top of the framework overhead.
-- Payload size has minimal impact on simple field operations — the cost scales with fix complexity, not data size.
+- Payload size has minimal impact on simple field operations - the cost scales with fix complexity, not data size.
 - A realistic domain fix (player data with multiple field transformations) takes ~9 µs.
 - End-to-end migration (including schema lookup and type routing) adds ~22 µs overhead on top of the raw fix.
 
@@ -110,7 +110,7 @@ Measures `SchemaRegistry` lookup speed with varying registry sizes.
 
 - **latestLookup is O(1)**: Near-constant time regardless of registry size. Always use `getCurrentVersion()` when you know you need the latest schema.
 - **exactLookup and floorLookup are O(log n)**: Based on `TreeMap` lookups. Even with 500 schemas, lookup takes only ~50 ns.
-- **sequentialLookup is O(n)**: Iterates through all schemas — 10.8 µs at 500 schemas. Avoid sequential iteration in hot paths.
+- **sequentialLookup is O(n)**: Iterates through all schemas - 10.8 µs at 500 schemas. Avoid sequential iteration in hot paths.
 
 ---
 
@@ -125,8 +125,8 @@ Measures raw field read, set, and object generation performance per `DynamicOps`
 | Format         |  SMALL |  MEDIUM |  LARGE |
 |----------------|-------:|--------:|-------:|
 | SnakeYamlOps   |  116.5 |   108.3 |  116.1 |
-| JacksonTomlOps |   62.3 |    62.4 |      — |
-| JacksonXmlOps  |   61.0 |    62.3 |      — |
+| JacksonTomlOps |   62.3 |    62.4 |      - |
+| JacksonXmlOps  |   61.0 |    62.3 |      - |
 | JacksonJsonOps |   60.1 |    60.7 |   62.0 |
 | JacksonYamlOps |   59.1 |    61.6 |   60.9 |
 | GsonOps        |   37.1 |    38.9 |   33.4 |
@@ -136,28 +136,28 @@ Measures raw field read, set, and object generation performance per `DynamicOps`
 | Format         |  SMALL |  MEDIUM |  LARGE |
 |----------------|-------:|--------:|-------:|
 | SnakeYamlOps   |  5.597 |   1.205 |  0.525 |
-| JacksonXmlOps  |  0.891 |   0.127 |      — |
+| JacksonXmlOps  |  0.891 |   0.127 |      - |
 | JacksonYamlOps |  0.888 |   0.126 |  0.014 |
 | JacksonJsonOps |  0.883 |   0.126 |  0.014 |
-| JacksonTomlOps |  0.880 |   0.129 |      — |
+| JacksonTomlOps |  0.880 |   0.129 |      - |
 | GsonOps        |  0.650 |   0.086 |  0.011 |
 
 #### Object Generation (ops/µs, higher is better)
 
 | Format         |  SMALL |  MEDIUM |  LARGE |
 |----------------|-------:|--------:|-------:|
-| JacksonXmlOps  |  0.150 |   0.015 |      — |
+| JacksonXmlOps  |  0.150 |   0.015 |      - |
 | JacksonYamlOps |  0.149 |   0.015 | 0.0019 |
 | JacksonJsonOps |  0.148 |   0.015 | 0.0019 |
-| JacksonTomlOps |  0.148 |   0.015 |      — |
+| JacksonTomlOps |  0.148 |   0.015 |      - |
 | GsonOps        |  0.106 |   0.007 | 0.0008 |
 | SnakeYamlOps   |  0.107 |   0.012 | 0.0014 |
 
 **Key takeaways:**
 
-- **SnakeYamlOps is the fastest for field reads** — 2–3x faster than Jackson-based implementations. This is because SnakeYaml uses native Java `Map`/`List` types with direct `HashMap.get()` lookups, while Jackson and Gson use tree node wrappers (`ObjectNode`, `JsonObject`).
-- **SnakeYamlOps is also the fastest for field sets** — 6x faster than Jackson at SMALL payloads, because Java `HashMap.put()` is an in-place mutation, while Jackson's `ObjectNode.set()` involves tree copying.
-- **All Jackson-based formats perform identically** for in-memory operations. JacksonJsonOps, JacksonYamlOps, JacksonTomlOps, and JacksonXmlOps share the same `ObjectNode`/`ArrayNode` tree model — format differences only matter during serialization/deserialization.
+- **SnakeYamlOps is the fastest for field reads** - 2–3x faster than Jackson-based implementations. This is because SnakeYaml uses native Java `Map`/`List` types with direct `HashMap.get()` lookups, while Jackson and Gson use tree node wrappers (`ObjectNode`, `JsonObject`).
+- **SnakeYamlOps is also the fastest for field sets** - 6x faster than Jackson at SMALL payloads, because Java `HashMap.put()` is an in-place mutation, while Jackson's `ObjectNode.set()` involves tree copying.
+- **All Jackson-based formats perform identically** for in-memory operations. JacksonJsonOps, JacksonYamlOps, JacksonTomlOps, and JacksonXmlOps share the same `ObjectNode`/`ArrayNode` tree model - format differences only matter during serialization/deserialization.
 - **GsonOps is consistently the slowest** for field operations due to `JsonObject.deepCopy()` on mutations.
 
 ### Migration Throughput
@@ -169,9 +169,9 @@ Measures end-to-end `DataFixer.update()` throughput per format (single rename fi
 | JacksonJsonOps |           3.709 |            3.759 |           3.734 |
 | JacksonYamlOps |           3.728 |            3.733 |           3.585 |
 | SnakeYamlOps   |           3.730 |            3.726 |           3.636 |
-| JacksonTomlOps |           3.633 |            3.636 |               — |
+| JacksonTomlOps |           3.633 |            3.636 |               - |
 | GsonOps        |           3.628 |            3.314 |           3.231 |
-| JacksonXmlOps  |           3.620 |            3.644 |               — |
+| JacksonXmlOps  |           3.620 |            3.644 |               - |
 
 **Key takeaway:** Migration throughput is nearly identical across all formats (~3.6–3.7 ops/µs). The DataFixer framework overhead dominates over format-specific differences. Choose your format based on your application's needs, not migration speed.
 
@@ -222,7 +222,7 @@ Measures encode and decode throughput for individual primitive values.
 
 **Key takeaways:**
 
-- String, Integer, and Boolean codecs operate at ~4 ns per operation — effectively free in the context of a migration.
+- String, Integer, and Boolean codecs operate at ~4 ns per operation - effectively free in the context of a migration.
 - Float, Long, and Double are ~40% slower due to boxing and number conversion overhead but still under 7 ns per operation.
 - Encoding is consistently ~5–10% faster than decoding.
 
@@ -248,7 +248,7 @@ Measures how list codec performance scales with collection size.
 
 **Key takeaways:**
 
-- Collection codecs scale linearly — 10x the items costs ~10x the time.
+- Collection codecs scale linearly - 10x the items costs ~10x the time.
 - Decoding is ~1.7x faster than encoding for both types.
 - String lists are slightly faster than integer lists due to avoiding unboxing overhead.
 - **Functional vs. direct round-trip**: Performance is identical for integer lists. For string lists, the functional API is ~15% slower at small sizes but converges at larger sizes.
@@ -265,8 +265,8 @@ Measures migration throughput under concurrent load.
 |--------------------------|---------------------:|---------------------:|---------------------:|
 | Single fix (SMALL)       |                12.32 |                12.32 |                12.54 |
 | Single fix (MEDIUM)      |                11.54 |                11.49 |                11.47 |
-| Chain migration (SMALL)  |                 1.91 |                    — |                    — |
-| Chain migration (MEDIUM) |                 1.77 |                    — |                    — |
+| Chain migration (SMALL)  |                 1.91 |                    - |                    - |
+| Chain migration (MEDIUM) |                 1.77 |                    - |                    - |
 
 ### Concurrent Registry Operations
 
@@ -277,7 +277,7 @@ Measures migration throughput under concurrent load.
 
 **Key takeaways:**
 
-- **DataFixer is fully thread-safe** with zero lock contention. Throughput stays constant from 2 to 8 threads — the framework scales linearly with available cores.
+- **DataFixer is fully thread-safe** with zero lock contention. Throughput stays constant from 2 to 8 threads - the framework scales linearly with available cores.
 - **Registry lookups are lock-free**: 481 ops/µs for latest lookup even under contention (2+ threads reading concurrently).
 - Migration throughput at 8 threads: **~12 million SMALL fix applications per second** and **~11.5 million MEDIUM fix applications per second**.
 - Payload size matters more than thread count: SMALL → MEDIUM causes ~7% throughput reduction, while doubling threads has no measurable impact.
@@ -310,7 +310,7 @@ java \
 ```
 
 - **`AlwaysPreTouch`**: Pre-allocates heap memory at startup, avoiding page faults during migration.
-- **`MaxGCPauseMillis=200`**: Keeps GC pauses under 200 ms — suitable for batch processing.
+- **`MaxGCPauseMillis=200`**: Keeps GC pauses under 200 ms - suitable for batch processing.
 - **`G1HeapRegionSize=16m`**: Larger regions reduce overhead for workloads with many medium-sized objects.
 
 ### Streaming vs. In-Memory Processing
@@ -318,13 +318,13 @@ java \
 For very large datasets, avoid loading all records into memory at once:
 
 ```java
-// In-memory: loads everything — fine for < 100k records
+// In-memory: loads everything - fine for < 100k records
 List<TaggedDynamic> all = loadAll();
 List<TaggedDynamic> migrated = all.stream()
     .map(item -> fixer.update(item, fromVersion, toVersion))
     .toList();
 
-// Streaming: processes one record at a time — use for > 100k records
+// Streaming: processes one record at a time - use for > 100k records
 try (Stream<TaggedDynamic> stream = loadStream()) {
     stream
         .map(item -> fixer.update(item, fromVersion, toVersion))
@@ -355,7 +355,7 @@ processBatch(batch); // remaining items
 
 ### Parallel Processing
 
-DataFixer is thread-safe — use parallel streams for CPU-bound migrations:
+DataFixer is thread-safe - use parallel streams for CPU-bound migrations:
 
 ```java
 List<TaggedDynamic> items = loadItems();
@@ -405,7 +405,7 @@ try (BufferedReader reader = Files.newBufferedReader(path)) {
 
 ### Lazy Schema Initialization
 
-Schemas are initialized lazily by default. Only schemas accessed during migration are fully constructed — no upfront cost for unused versions.
+Schemas are initialized lazily by default. Only schemas accessed during migration are fully constructed - no upfront cost for unused versions.
 
 ### Minimize Dynamic Operations
 
@@ -460,9 +460,9 @@ if (elapsed > THRESHOLD_NANOS) {
 
 Based on the [schema lookup benchmarks](#schema-lookup-performance):
 
-- Use `getCurrentVersion()` for the latest schema — **O(1), 5.7 ns**
-- Use `getSchema(version)` for a specific version — **O(log n), 9–52 ns**
-- Avoid iterating schemas sequentially — **O(n), up to 10.8 µs at 500 schemas**
+- Use `getCurrentVersion()` for the latest schema - **O(1), 5.7 ns**
+- Use `getSchema(version)` for a specific version - **O(log n), 9–52 ns**
+- Avoid iterating schemas sequentially - **O(n), up to 10.8 µs at 500 schemas**
 
 ---
 
@@ -471,4 +471,4 @@ Based on the [schema lookup benchmarks](#schema-lookup-performance):
 - [Concurrent Migrations](concurrent-migrations.md)
 - [Debug Migrations](../how-to/debug-migrations.md)
 - [Monitoring & Alerting](../operations/monitoring-alerting.md)
-- [Benchmark Module](../../aether-datafixers-benchmarks/) — JMH benchmark source code
+- [Benchmark Module](../../aether-datafixers-benchmarks/) - JMH benchmark source code

--- a/docs/appendix/changelog.md
+++ b/docs/appendix/changelog.md
@@ -20,7 +20,7 @@ The `SchemaValidator.validateFixCoverage()` method now performs actual coverage 
 - Reports issues as `ValidationIssue` warnings with location and context
 
 Updated documentation:
-- [Schema Validation](../schema-tools/schema-validation.md) — Updated with fix coverage validation examples
+- [Schema Validation](../schema-tools/schema-validation.md) - Updated with fix coverage validation examples
 
 ### MigrationService.withOps() Support
 
@@ -31,7 +31,7 @@ The Spring Boot `MigrationService` now fully supports custom `DynamicOps`:
 - Supports all DynamicOps implementations (Gson, Jackson, YAML, TOML, XML)
 
 Updated documentation:
-- [MigrationService API](../spring-boot/migration-service.md) — Added withOps() usage examples
+- [MigrationService API](../spring-boot/migration-service.md) - Added withOps() usage examples
 
 ### Functional Tests Module
 
@@ -45,13 +45,13 @@ New `aether-datafixers-functional-tests` module with comprehensive E2E and integ
 
 Extended the CLI with four new format handlers for YAML, TOML, and XML support:
 
-- **yaml-snakeyaml** — YAML support using SnakeYAML with native Java types
-- **yaml-jackson** — YAML support using Jackson YAML with JsonNode
-- **toml-jackson** — TOML support using Jackson TOML with JsonNode
-- **xml-jackson** — XML support using Jackson XML with JsonNode
+- **yaml-snakeyaml** - YAML support using SnakeYAML with native Java types
+- **yaml-jackson** - YAML support using Jackson YAML with JsonNode
+- **toml-jackson** - TOML support using Jackson TOML with JsonNode
+- **xml-jackson** - XML support using Jackson XML with JsonNode
 
 Updated documentation:
-- [Format Handlers](../cli/format-handlers.md) — Added sections for all new handlers, updated output examples
+- [Format Handlers](../cli/format-handlers.md) - Added sections for all new handlers, updated output examples
 
 ### Testkit: New Factory Methods
 
@@ -66,12 +66,12 @@ Added new format-specific factory methods to `TestData`:
 | `jacksonXml()`  | XML          | `JsonNode`  |
 
 Updated documentation:
-- [Test Data Builders](../testkit/test-data-builders.md) — Added new factory methods and format examples
+- [Test Data Builders](../testkit/test-data-builders.md) - Added new factory methods and format examples
 
 ### Deprecations
 
-- **`TestData.jackson()`** — Deprecated since 0.5.0, use `jacksonJson()` instead. Will be removed in 1.0.0.
-- **`JacksonOps`** — Already deprecated in 0.4.0, use `JacksonJsonOps` instead. Will be removed in 1.0.0.
+- **`TestData.jackson()`** - Deprecated since 0.5.0, use `jacksonJson()` instead. Will be removed in 1.0.0.
+- **`JacksonOps`** - Already deprecated in 0.4.0, use `JacksonJsonOps` instead. Will be removed in 1.0.0.
 
 ---
 
@@ -81,11 +81,11 @@ Updated documentation:
 
 Added comprehensive documentation for all DynamicOps implementations in the codec module:
 
-- [Codec Overview](../codec/index.md) — Introduction, format comparison, package structure
-- [JSON Support](../codec/json.md) — GsonOps and JacksonJsonOps documentation
-- [YAML Support](../codec/yaml.md) — SnakeYamlOps and JacksonYamlOps documentation
-- [TOML Support](../codec/toml.md) — JacksonTomlOps documentation
-- [XML Support](../codec/xml.md) — JacksonXmlOps documentation
+- [Codec Overview](../codec/index.md) - Introduction, format comparison, package structure
+- [JSON Support](../codec/json.md) - GsonOps and JacksonJsonOps documentation
+- [YAML Support](../codec/yaml.md) - SnakeYamlOps and JacksonYamlOps documentation
+- [TOML Support](../codec/toml.md) - JacksonTomlOps documentation
+- [XML Support](../codec/xml.md) - JacksonXmlOps documentation
 
 ### Key Codec Features Documented
 
@@ -112,13 +112,13 @@ Added comprehensive documentation for all DynamicOps implementations in the code
 
 Added comprehensive documentation for the Spring Boot Starter module:
 
-- [Spring Boot Overview](../spring-boot/index.md) — Introduction, architecture diagram, auto-configuration classes
-- [Quick Start Guide](../spring-boot/getting-started.md) — Step-by-step tutorial with complete code examples
-- [Configuration Reference](../spring-boot/configuration.md) — Complete property reference (YAML and properties format)
-- [MigrationService API](../spring-boot/migration-service.md) — Fluent API documentation, sync/async patterns, error handling
-- [Multi-Domain Setup](../spring-boot/multi-domain.md) — Managing multiple DataFixer instances with `@Qualifier`
-- [Actuator Integration](../spring-boot/actuator.md) — Health indicators, info contributors, custom endpoints, security
-- [Metrics Integration](../spring-boot/metrics.md) — Micrometer metrics, PromQL queries, Grafana dashboard, alerting rules
+- [Spring Boot Overview](../spring-boot/index.md) - Introduction, architecture diagram, auto-configuration classes
+- [Quick Start Guide](../spring-boot/getting-started.md) - Step-by-step tutorial with complete code examples
+- [Configuration Reference](../spring-boot/configuration.md) - Complete property reference (YAML and properties format)
+- [MigrationService API](../spring-boot/migration-service.md) - Fluent API documentation, sync/async patterns, error handling
+- [Multi-Domain Setup](../spring-boot/multi-domain.md) - Managing multiple DataFixer instances with `@Qualifier`
+- [Actuator Integration](../spring-boot/actuator.md) - Health indicators, info contributors, custom endpoints, security
+- [Metrics Integration](../spring-boot/metrics.md) - Micrometer metrics, PromQL queries, Grafana dashboard, alerting rules
 
 ### Key Features Documented
 
@@ -131,12 +131,12 @@ Added comprehensive documentation for the Spring Boot Starter module:
 
 ### Updated Pages
 
-- [Main README](../README.md) — Added Codec Formats and Spring Boot Integration sections, updated module table
-- [Codec System](../concepts/codec-system.md) — Added links to format-specific documentation
-- [Dynamic System](../concepts/dynamic-system.md) — Added table of all DynamicOps implementations
-- [How-To Index](../how-to/index.md) — Added Format Integration section
-- [Custom DynamicOps Tutorial](../tutorials/custom-dynamicops.md) — Added reference to built-in implementations
-- [Installation Guide](../getting-started/installation.md) — Added Spring Boot module to overview and installation section
+- [Main README](../README.md) - Added Codec Formats and Spring Boot Integration sections, updated module table
+- [Codec System](../concepts/codec-system.md) - Added links to format-specific documentation
+- [Dynamic System](../concepts/dynamic-system.md) - Added table of all DynamicOps implementations
+- [How-To Index](../how-to/index.md) - Added Format Integration section
+- [Custom DynamicOps Tutorial](../tutorials/custom-dynamicops.md) - Added reference to built-in implementations
+- [Installation Guide](../getting-started/installation.md) - Added Spring Boot module to overview and installation section
 
 ---
 
@@ -146,26 +146,26 @@ Added comprehensive documentation for the Spring Boot Starter module:
 
 Added complete documentation for the new schema tools module:
 
-- [Schema Tools Overview](../schema-tools/index.md) — Introduction, use cases, and quick start
-- [Schema Diffing](../schema-tools/schema-diffing.md) — Compare schemas and detect type/field changes
-- [Migration Analysis](../schema-tools/migration-analysis.md) — Analyze migration paths and fix coverage
-- [Schema Validation](../schema-tools/schema-validation.md) — Validate structure and naming conventions
-- [Type Introspection](../schema-tools/type-introspection.md) — Inspect type structures and extract field metadata
+- [Schema Tools Overview](../schema-tools/index.md) - Introduction, use cases, and quick start
+- [Schema Diffing](../schema-tools/schema-diffing.md) - Compare schemas and detect type/field changes
+- [Migration Analysis](../schema-tools/migration-analysis.md) - Analyze migration paths and fix coverage
+- [Schema Validation](../schema-tools/schema-validation.md) - Validate structure and naming conventions
+- [Type Introspection](../schema-tools/type-introspection.md) - Inspect type structures and extract field metadata
 
 ### New Section: CLI Module
 
 Added complete documentation for the new CLI module:
 
-- [CLI Overview](../cli/index.md) — Introduction, quick start, and workflow diagram
-- [Installation](../cli/installation.md) — Build instructions, aliases, classpath setup
-- [Command Reference](../cli/commands.md) — Detailed options for migrate, validate, info
-- [Format Handlers](../cli/format-handlers.md) — Custom format handler development guide
-- [Examples](../cli/examples.md) — 11 practical usage scenarios (CI/CD, Docker, scripting)
+- [CLI Overview](../cli/index.md) - Introduction, quick start, and workflow diagram
+- [Installation](../cli/installation.md) - Build instructions, aliases, classpath setup
+- [Command Reference](../cli/commands.md) - Detailed options for migrate, validate, info
+- [Format Handlers](../cli/format-handlers.md) - Custom format handler development guide
+- [Examples](../cli/examples.md) - 11 practical usage scenarios (CI/CD, Docker, scripting)
 
 ### Updated Pages
 
-- [Main README](../README.md) — Added CLI and Schema Tools to navigation and module table
-- [Installation Guide](../getting-started/installation.md) — Added CLI module to overview table
+- [Main README](../README.md) - Added CLI and Schema Tools to navigation and module table
+- [Installation Guide](../getting-started/installation.md) - Added CLI module to overview table
 
 ---
 
@@ -175,27 +175,27 @@ Added complete documentation for the new CLI module:
 
 Added complete documentation for the testkit module:
 
-- [Testkit Overview](../testkit/index.md) — Introduction to testing utilities
-- [Test Data Builders](../testkit/test-data-builders.md) — Fluent API for test data
-- [Custom Assertions](../testkit/assertions.md) — AssertJ assertions for Dynamic, DataResult, Typed
-- [DataFixTester](../testkit/datafix-tester.md) — Test harness for isolated DataFix testing
-- [QuickFix Factories](../testkit/quick-fix.md) — Factory methods for common fix patterns
-- [Mock Schemas](../testkit/mock-schemas.md) — Mock schema utilities
+- [Testkit Overview](../testkit/index.md) - Introduction to testing utilities
+- [Test Data Builders](../testkit/test-data-builders.md) - Fluent API for test data
+- [Custom Assertions](../testkit/assertions.md) - AssertJ assertions for Dynamic, DataResult, Typed
+- [DataFixTester](../testkit/datafix-tester.md) - Test harness for isolated DataFix testing
+- [QuickFix Factories](../testkit/quick-fix.md) - Factory methods for common fix patterns
+- [Mock Schemas](../testkit/mock-schemas.md) - Mock schema utilities
 
 ### New How-To Guides
 
-- [Batch Operations](../how-to/batch-operations.md) — Rename/remove multiple fields
-- [Group Fields](../how-to/group-fields.md) — Grouping and flattening structures
-- [Conditional Rules](../how-to/conditional-rules.md) — Conditional rule application
-- [Use Diagnostics](../how-to/use-diagnostics.md) — Migration diagnostics guide
-- [Test Migrations](../how-to/test-migrations.md) — Testing migrations with testkit
+- [Batch Operations](../how-to/batch-operations.md) - Rename/remove multiple fields
+- [Group Fields](../how-to/group-fields.md) - Grouping and flattening structures
+- [Conditional Rules](../how-to/conditional-rules.md) - Conditional rule application
+- [Use Diagnostics](../how-to/use-diagnostics.md) - Migration diagnostics guide
+- [Test Migrations](../how-to/test-migrations.md) - Testing migrations with testkit
 
 ### Updated Pages
 
-- [Rewrite Rules](../concepts/rewrite-rules.md) — Extended rules section
-- [Concepts Index](../concepts/index.md) — Extended rules examples
-- [How-To Index](../how-to/index.md) — Links to new guides
-- [Glossary](glossary.md) — Testkit terminology
+- [Rewrite Rules](../concepts/rewrite-rules.md) - Extended rules section
+- [Concepts Index](../concepts/index.md) - Extended rules examples
+- [How-To Index](../how-to/index.md) - Links to new guides
+- [Glossary](glossary.md) - Testkit terminology
 
 ---
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -317,5 +317,5 @@ Custom handlers can be added via ServiceLoader. See [Format Handlers](format-han
 
 ## Next Steps
 
-→ [Format Handlers](format-handlers.md) — Create custom format handlers
-→ [Examples](examples.md) — Real-world usage examples
+→ [Format Handlers](format-handlers.md) - Create custom format handlers
+→ [Examples](examples.md) - Real-world usage examples

--- a/docs/cli/examples.md
+++ b/docs/cli/examples.md
@@ -437,5 +437,5 @@ docker run -v $(pwd)/data:/data aether-cli migrate \
 
 ## Next Steps
 
-→ [Command Reference](commands.md) — Full option documentation
-→ [Format Handlers](format-handlers.md) — Support additional formats
+→ [Command Reference](commands.md) - Full option documentation
+→ [Format Handlers](format-handlers.md) - Support additional formats

--- a/docs/cli/format-handlers.md
+++ b/docs/cli/format-handlers.md
@@ -436,4 +436,4 @@ public class YamlFormatHandler implements FormatHandler<YamlNode> {
 
 ## Next Steps
 
-→ [Examples](examples.md) — See format handlers in real-world scenarios
+→ [Examples](examples.md) - See format handlers in real-world scenarios

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -89,13 +89,13 @@ Custom format handlers can be added via the ServiceLoader SPI.
 
 ## In This Section
 
-- [Installation](installation.md) — Build and run the CLI
-- [Command Reference](commands.md) — Detailed options for each command
-- [Format Handlers](format-handlers.md) — Create custom format handlers
-- [Examples](examples.md) — Real-world usage examples
+- [Installation](installation.md) - Build and run the CLI
+- [Command Reference](commands.md) - Detailed options for each command
+- [Format Handlers](format-handlers.md) - Create custom format handlers
+- [Examples](examples.md) - Real-world usage examples
 
 ---
 
 ## Next Steps
 
-→ [Installation](installation.md) — Set up the CLI tool
+→ [Installation](installation.md) - Set up the CLI tool

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -216,4 +216,4 @@ java -version
 
 ## Next Steps
 
-→ [Command Reference](commands.md) — Learn all available options
+→ [Command Reference](commands.md) - Learn all available options

--- a/docs/codec/index.md
+++ b/docs/codec/index.md
@@ -222,10 +222,10 @@ migrator.migrate(xmlDynamic, v1, v2);    // XML
 
 ## Related Documentation
 
-- [JSON Support](json.md) — GsonOps and JacksonJsonOps details
-- [YAML Support](yaml.md) — SnakeYamlOps and JacksonYamlOps details
-- [TOML Support](toml.md) — JacksonTomlOps details
-- [XML Support](xml.md) — JacksonXmlOps details
-- [Dynamic System](../concepts/dynamic-system.md) — Core Dynamic concepts
-- [Codec System](../concepts/codec-system.md) — Encoding and decoding
-- [Custom DynamicOps](../tutorials/custom-dynamicops.md) — Create your own implementation
+- [JSON Support](json.md) - GsonOps and JacksonJsonOps details
+- [YAML Support](yaml.md) - SnakeYamlOps and JacksonYamlOps details
+- [TOML Support](toml.md) - JacksonTomlOps details
+- [XML Support](xml.md) - JacksonXmlOps details
+- [Dynamic System](../concepts/dynamic-system.md) - Core Dynamic concepts
+- [Codec System](../concepts/codec-system.md) - Encoding and decoding
+- [Custom DynamicOps](../tutorials/custom-dynamicops.md) - Create your own implementation

--- a/docs/codec/yaml.md
+++ b/docs/codec/yaml.md
@@ -140,10 +140,10 @@ Object data = yaml.load(untrustedYaml);
 
 **Critical security measures for untrusted YAML:**
 
-1. **Always use `SafeConstructor`** — Prevents arbitrary class instantiation
-2. **Limit alias expansion** — Set `maxAliasesForCollections` to prevent Billion Laughs attacks
-3. **Limit nesting depth** — Set `nestingDepthLimit` to prevent stack overflow
-4. **Limit input size** — Set `codePointLimit` to prevent memory exhaustion
+1. **Always use `SafeConstructor`** - Prevents arbitrary class instantiation
+2. **Limit alias expansion** - Set `maxAliasesForCollections` to prevent Billion Laughs attacks
+3. **Limit nesting depth** - Set `nestingDepthLimit` to prevent stack overflow
+4. **Limit input size** - Set `codePointLimit` to prevent memory exhaustion
 
 ```java
 // Secure configuration for untrusted YAML

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -349,7 +349,7 @@ Rules, codecs, and optics all support composition, enabling complex transformati
 
 ## Next Steps
 
-- [DataVersion](data-version.md) — Understanding version identifiers
-- [TypeReference](type-reference.md) — Type identification system
-- [Schema System](schema-system.md) — Defining data structures
+- [DataVersion](data-version.md) - Understanding version identifiers
+- [TypeReference](type-reference.md) - Type identification system
+- [Schema System](schema-system.md) - Defining data structures
 

--- a/docs/concepts/codec-system.md
+++ b/docs/concepts/codec-system.md
@@ -476,17 +476,17 @@ public static final Codec<Player> CODEC = ...;
 
 ## Related
 
-- [Dynamic System](dynamic-system.md) — Format-agnostic data
-- [Type System](type-system.md) — Types contain codecs
-- [DataResult](data-result.md) — Error handling
+- [Dynamic System](dynamic-system.md) - Format-agnostic data
+- [Type System](type-system.md) - Types contain codecs
+- [DataResult](data-result.md) - Error handling
 
 ## Format-Specific Documentation
 
 For detailed documentation on `DynamicOps` implementations:
 
-- [Codec Module Overview](../codec/index.md) — All available implementations
-- [JSON Support](../codec/json.md) — GsonOps and JacksonJsonOps
-- [YAML Support](../codec/yaml.md) — SnakeYamlOps and JacksonYamlOps
-- [TOML Support](../codec/toml.md) — JacksonTomlOps
-- [XML Support](../codec/xml.md) — JacksonXmlOps
+- [Codec Module Overview](../codec/index.md) - All available implementations
+- [JSON Support](../codec/json.md) - GsonOps and JacksonJsonOps
+- [YAML Support](../codec/yaml.md) - SnakeYamlOps and JacksonYamlOps
+- [TOML Support](../codec/toml.md) - JacksonTomlOps
+- [XML Support](../codec/xml.md) - JacksonXmlOps
 

--- a/docs/concepts/data-result.md
+++ b/docs/concepts/data-result.md
@@ -444,7 +444,7 @@ DataResult<String> displayName = loadPlayer(id)
 
 ## Related
 
-- [Dynamic System](dynamic-system.md) — Returns DataResult for operations
-- [Codec System](codec-system.md) — Encode/decode with DataResult
-- [Type System](type-system.md) — Type operations use DataResult
+- [Dynamic System](dynamic-system.md) - Returns DataResult for operations
+- [Codec System](codec-system.md) - Encode/decode with DataResult
+- [Type System](type-system.md) - Type operations use DataResult
 

--- a/docs/concepts/data-version.md
+++ b/docs/concepts/data-version.md
@@ -291,7 +291,7 @@ public <T> TaggedDynamic updateIfNeeded(
 
 ## Related
 
-- [TypeReference](type-reference.md) — Type identifiers for data routing
-- [Schema System](schema-system.md) — Associating versions with type definitions
-- [DataFix System](datafix-system.md) — Creating migrations between versions
+- [TypeReference](type-reference.md) - Type identifiers for data routing
+- [Schema System](schema-system.md) - Associating versions with type definitions
+- [DataFix System](datafix-system.md) - Creating migrations between versions
 

--- a/docs/concepts/datafix-system.md
+++ b/docs/concepts/datafix-system.md
@@ -494,7 +494,7 @@ void testPlayerV1ToV2Migration() {
 
 ## Related
 
-- [Rewrite Rules](rewrite-rules.md) — Rule combinators in detail
-- [Schema System](schema-system.md) — Where types are defined
-- [Dynamic System](dynamic-system.md) — Data manipulation
+- [Rewrite Rules](rewrite-rules.md) - Rule combinators in detail
+- [Schema System](schema-system.md) - Where types are defined
+- [Dynamic System](dynamic-system.md) - Data manipulation
 

--- a/docs/concepts/dsl.md
+++ b/docs/concepts/dsl.md
@@ -468,7 +468,7 @@ DSL.taggedChoice("type", DSL.string(), variants)
 
 ## Related
 
-- [Schema System](schema-system.md) — Where DSL is used
-- [Type System](type-system.md) — Templates become Types
-- [Codec System](codec-system.md) — Encoding/decoding
+- [Schema System](schema-system.md) - Where DSL is used
+- [Type System](type-system.md) - Templates become Types
+- [Codec System](codec-system.md) - Encoding/decoding
 

--- a/docs/concepts/dynamic-system.md
+++ b/docs/concepts/dynamic-system.md
@@ -169,7 +169,7 @@ if (result.result().isPresent()) {
 
 ## Modifying Values
 
-`Dynamic` is **immutable** — all operations return new instances:
+`Dynamic` is **immutable** - all operations return new instances:
 
 ### Setting Fields
 
@@ -517,8 +517,8 @@ See [Codec Module Documentation](../codec/index.md) for detailed usage of each i
 
 ## Related
 
-- [Codec System](codec-system.md) — Encoding/decoding typed data
-- [Codec Module](../codec/index.md) — All DynamicOps implementations
-- [DataFix System](datafix-system.md) — Using Dynamic in fixes
-- [DSL](dsl.md) — Type templates with remainder
+- [Codec System](codec-system.md) - Encoding/decoding typed data
+- [Codec Module](../codec/index.md) - All DynamicOps implementations
+- [DataFix System](datafix-system.md) - Using Dynamic in fixes
+- [DSL](dsl.md) - Type templates with remainder
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -163,18 +163,18 @@ TaggedDynamic migrated = fixer.update(
 
 For newcomers, we recommend reading the concepts in this order:
 
-1. **[Architecture Overview](architecture-overview.md)** — Understand the big picture
-2. **[DataVersion](data-version.md)** — Version numbering
-3. **[TypeReference](type-reference.md)** — Type identification
-4. **[Schema System](schema-system.md)** — Defining data structures
-5. **[DataFix System](datafix-system.md)** — Creating migrations
-6. **[Dynamic System](dynamic-system.md)** — Data manipulation
-7. **[DSL](dsl.md)** — Type template language
-8. **[Rewrite Rules](rewrite-rules.md)** — Transformation rules
-9. **[Codec System](codec-system.md)** — Encoding/decoding
-10. **[Optics](optics/index.md)** — Advanced data access
-11. **[DataResult](data-result.md)** — Error handling
-12. **[Thread Safety](thread-safety.md)** — Concurrency
+1. **[Architecture Overview](architecture-overview.md)** - Understand the big picture
+2. **[DataVersion](data-version.md)** - Version numbering
+3. **[TypeReference](type-reference.md)** - Type identification
+4. **[Schema System](schema-system.md)** - Defining data structures
+5. **[DataFix System](datafix-system.md)** - Creating migrations
+6. **[Dynamic System](dynamic-system.md)** - Data manipulation
+7. **[DSL](dsl.md)** - Type template language
+8. **[Rewrite Rules](rewrite-rules.md)** - Transformation rules
+9. **[Codec System](codec-system.md)** - Encoding/decoding
+10. **[Optics](optics/index.md)** - Advanced data access
+11. **[DataResult](data-result.md)** - Error handling
+12. **[Thread Safety](thread-safety.md)** - Concurrency
 
 ---
 

--- a/docs/concepts/optics/affine.md
+++ b/docs/concepts/optics/affine.md
@@ -22,8 +22,8 @@ public interface Affine<S, A> extends Optic<S, A> {
 ```
 
 **Type Parameters:**
-- `S` — The source type (whole structure)
-- `A` — The focus type (the optional part)
+- `S` - The source type (whole structure)
+- `A` - The focus type (the optional part)
 
 ## Conceptual Model
 
@@ -332,8 +332,8 @@ assert userEmail.set(user, email.get()).equals(user);
 
 ## Related
 
-- [Lens](lens.md) — For required fields
-- [Prism](prism.md) — For sum type cases
-- [Finder](finder.md) — For Dynamic data navigation
-- [Optics Overview](index.md) — Optic hierarchy
+- [Lens](lens.md) - For required fields
+- [Prism](prism.md) - For sum type cases
+- [Finder](finder.md) - For Dynamic data navigation
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/optics/finder.md
+++ b/docs/concepts/optics/finder.md
@@ -15,7 +15,7 @@ public interface Finder<A> {
 ```
 
 **Type Parameter:**
-- `A` — The type of value being extracted
+- `A` - The type of value being extracted
 
 ## Conceptual Model
 
@@ -366,7 +366,7 @@ public List<String> extractNames(Dynamic<?> data) {
 
 ## Related
 
-- [Dynamic System](../dynamic-system.md) — The data Finder navigates
-- [Affine](affine.md) — Similar optional semantics
-- [Optics Overview](index.md) — Optic hierarchy
+- [Dynamic System](../dynamic-system.md) - The data Finder navigates
+- [Affine](affine.md) - Similar optional semantics
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/optics/getter.md
+++ b/docs/concepts/optics/getter.md
@@ -1,6 +1,6 @@
 # Getter
 
-A **Getter** is the simplest optic — it provides read-only access to a value. Unlike a Lens, a Getter cannot update the focused value; it can only extract it.
+A **Getter** is the simplest optic - it provides read-only access to a value. Unlike a Lens, a Getter cannot update the focused value; it can only extract it.
 
 ## Definition
 
@@ -12,8 +12,8 @@ public interface Getter<S, A> extends Optic<S, A> {
 ```
 
 **Type Parameters:**
-- `S` — The source type (whole structure)
-- `A` — The focus type (the part being read)
+- `S` - The source type (whole structure)
+- `A` - The focus type (the part being read)
 
 ## Conceptual Model
 
@@ -269,7 +269,7 @@ A Getter cannot be "promoted" to a Lens because it lacks update capability.
 
 ## Related
 
-- [Lens](lens.md) — Read-write access
-- [Affine](affine.md) — Optional read-write
-- [Optics Overview](index.md) — Optic hierarchy
+- [Lens](lens.md) - Read-write access
+- [Affine](affine.md) - Optional read-write
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/optics/index.md
+++ b/docs/concepts/optics/index.md
@@ -246,19 +246,19 @@ Lens<PlayerRecord, String> recordName = ...;
 
 ## Detailed Guides
 
-- [Lens](lens.md) — Focus on exactly one field
-- [Prism](prism.md) — Focus on a variant
-- [Iso](iso.md) — Bidirectional conversion
-- [Affine](affine.md) — Optional focus
-- [Traversal](traversal.md) — Multiple focus points
-- [Getter](getter.md) — Read-only access
-- [Finder](finder.md) — Dynamic data navigation
+- [Lens](lens.md) - Focus on exactly one field
+- [Prism](prism.md) - Focus on a variant
+- [Iso](iso.md) - Bidirectional conversion
+- [Affine](affine.md) - Optional focus
+- [Traversal](traversal.md) - Multiple focus points
+- [Getter](getter.md) - Read-only access
+- [Finder](finder.md) - Dynamic data navigation
 
 ---
 
 ## Related
 
-- [DSL](../dsl.md) — Type definitions with optic support
-- [Dynamic System](../dynamic-system.md) — Where Finder is used
-- [Rewrite Rules](../rewrite-rules.md) — Rules use optics internally
+- [DSL](../dsl.md) - Type definitions with optic support
+- [Dynamic System](../dynamic-system.md) - Where Finder is used
+- [Rewrite Rules](../rewrite-rules.md) - Rules use optics internally
 

--- a/docs/concepts/optics/iso.md
+++ b/docs/concepts/optics/iso.md
@@ -20,8 +20,8 @@ public interface Iso<S, A> extends Optic<S, A> {
 ```
 
 **Type Parameters:**
-- `S` — The source type
-- `A` — The target type
+- `S` - The source type
+- `A` - The target type
 
 ## Conceptual Model
 
@@ -317,7 +317,7 @@ Iso<String, String> identity = Iso.of(
 
 ## Related
 
-- [Lens](lens.md) — For field access
-- [Prism](prism.md) — For partial conversion
-- [Optics Overview](index.md) — Optic hierarchy
+- [Lens](lens.md) - For field access
+- [Prism](prism.md) - For partial conversion
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/optics/lens.md
+++ b/docs/concepts/optics/lens.md
@@ -20,8 +20,8 @@ public interface Lens<S, A> extends Optic<S, A> {
 ```
 
 **Type Parameters:**
-- `S` — The source type (whole structure)
-- `A` — The focus type (the part you're accessing)
+- `S` - The source type (whole structure)
+- `A` - The focus type (the part you're accessing)
 
 ## Creating Lenses
 
@@ -334,8 +334,8 @@ Player player = modifyIf(playerLevel, player, level -> level < 100, level -> lev
 
 ## Related
 
-- [Affine](affine.md) — For optional fields
-- [Prism](prism.md) — For sum type cases
-- [Iso](iso.md) — For bidirectional conversion
-- [Optics Overview](index.md) — Optic hierarchy
+- [Affine](affine.md) - For optional fields
+- [Prism](prism.md) - For sum type cases
+- [Iso](iso.md) - For bidirectional conversion
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/optics/prism.md
+++ b/docs/concepts/optics/prism.md
@@ -15,8 +15,8 @@ public interface Prism<S, A> extends Optic<S, A> {
 ```
 
 **Type Parameters:**
-- `S` — The sum type (the whole)
-- `A` — The focused case type (the part)
+- `S` - The sum type (the whole)
+- `A` - The focused case type (the part)
 
 ## Conceptual Model
 
@@ -333,8 +333,8 @@ public List<Entity> levelUpPlayers(List<Entity> entities) {
 
 ## Related
 
-- [Lens](lens.md) — For product type fields
-- [Affine](affine.md) — For optional access
-- [Iso](iso.md) — For bidirectional conversion
-- [Optics Overview](index.md) — Optic hierarchy
+- [Lens](lens.md) - For product type fields
+- [Affine](affine.md) - For optional access
+- [Iso](iso.md) - For bidirectional conversion
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/optics/traversal.md
+++ b/docs/concepts/optics/traversal.md
@@ -20,8 +20,8 @@ public interface Traversal<S, A> extends Optic<S, A> {
 ```
 
 **Type Parameters:**
-- `S` — The source type (whole structure)
-- `A` — The focus type (each element)
+- `S` - The source type (whole structure)
+- `A` - The focus type (each element)
 
 ## Conceptual Model
 
@@ -335,8 +335,8 @@ assert result1.equals(result2);
 
 ## Related
 
-- [Lens](lens.md) — Single-focus access
-- [Affine](affine.md) — Optional access
-- [Finder](finder.md) — Dynamic data navigation
-- [Optics Overview](index.md) — Optic hierarchy
+- [Lens](lens.md) - Single-focus access
+- [Affine](affine.md) - Optional access
+- [Finder](finder.md) - Dynamic data navigation
+- [Optics Overview](index.md) - Optic hierarchy
 

--- a/docs/concepts/rewrite-rules.md
+++ b/docs/concepts/rewrite-rules.md
@@ -143,7 +143,7 @@ Rules.seq(
 )
 ```
 
-**Order matters** — later rules see the result of earlier rules:
+**Order matters** - later rules see the result of earlier rules:
 
 ```java
 // Correct: rename first, then transform
@@ -633,7 +633,7 @@ void testGameModeConversion() {
 
 ## Related
 
-- [DataFix System](datafix-system.md) — Where rules are used
-- [Dynamic System](dynamic-system.md) — Data manipulation
-- [Schema System](schema-system.md) — Input/output schemas
+- [DataFix System](datafix-system.md) - Where rules are used
+- [Dynamic System](dynamic-system.md) - Data manipulation
+- [Schema System](schema-system.md) - Input/output schemas
 

--- a/docs/concepts/schema-system.md
+++ b/docs/concepts/schema-system.md
@@ -467,7 +467,7 @@ Schema definitions should never change after release. If you need to modify a ty
 
 ## Related
 
-- [Type System](type-system.md) — Type and TypeRegistry details
-- [DSL](dsl.md) — Type template language reference
-- [DataFix System](datafix-system.md) — Using schemas in fixes
+- [Type System](type-system.md) - Type and TypeRegistry details
+- [DSL](dsl.md) - Type template language reference
+- [DataFix System](datafix-system.md) - Using schemas in fixes
 

--- a/docs/concepts/thread-safety.md
+++ b/docs/concepts/thread-safety.md
@@ -39,7 +39,7 @@ The following types are immutable and fully thread-safe:
 
 ### Dynamic Operations
 
-`Dynamic` is immutable — all operations return new instances:
+`Dynamic` is immutable - all operations return new instances:
 
 ```java
 Dynamic<JsonElement> original = new Dynamic<>(GsonOps.INSTANCE, json);
@@ -304,7 +304,7 @@ For high-throughput scenarios:
 
 ## Related
 
-- [DataFix System](datafix-system.md) — Creating thread-safe fixes
-- [Dynamic System](dynamic-system.md) — Immutable data wrapper
-- [Architecture Overview](architecture-overview.md) — Framework design
+- [DataFix System](datafix-system.md) - Creating thread-safe fixes
+- [Dynamic System](dynamic-system.md) - Immutable data wrapper
+- [Architecture Overview](architecture-overview.md) - Framework design
 

--- a/docs/concepts/type-reference.md
+++ b/docs/concepts/type-reference.md
@@ -323,7 +323,7 @@ public static final TypeReference OBJECT = new TypeReference("object");
 
 ## Related
 
-- [DataVersion](data-version.md) — Version identifiers for schemas
-- [Schema System](schema-system.md) — Registering types per version
-- [Dynamic System](dynamic-system.md) — TaggedDynamic for typed data
+- [DataVersion](data-version.md) - Version identifiers for schemas
+- [Schema System](schema-system.md) - Registering types per version
+- [Dynamic System](dynamic-system.md) - TaggedDynamic for typed data
 

--- a/docs/concepts/type-system.md
+++ b/docs/concepts/type-system.md
@@ -466,7 +466,7 @@ registerType(TypeReferences.CONFIG, DSL.and(
 
 ## Related
 
-- [Schema System](schema-system.md) — Where types are registered
-- [DSL](dsl.md) — Type template language
-- [Codec System](codec-system.md) — Encoding/decoding types
+- [Schema System](schema-system.md) - Where types are registered
+- [DSL](dsl.md) - Type template language
+- [Codec System](codec-system.md) - Encoding/decoding types
 

--- a/docs/examples/configuration-example.md
+++ b/docs/examples/configuration-example.md
@@ -372,10 +372,10 @@ public class ConfigMigrator {
 
 ## Key Patterns Demonstrated
 
-1. **Flat to nested restructuring** — Group related settings
-2. **Adding defaults** — New settings with sensible defaults
-3. **Feature flags** — Conditional behavior toggles
-4. **Version detection** — Infer version from structure
+1. **Flat to nested restructuring** - Group related settings
+2. **Adding defaults** - New settings with sensible defaults
+3. **Feature flags** - Conditional behavior toggles
+4. **Version detection** - Infer version from structure
 
 ## Related
 

--- a/docs/examples/entity-polymorphism-example.md
+++ b/docs/examples/entity-polymorphism-example.md
@@ -378,10 +378,10 @@ public class EntityMigrator {
 
 ## Key Patterns Demonstrated
 
-1. **TaggedChoice** — Type discriminator for polymorphic data
-2. **Type-specific fixes** — Different migrations per entity type
-3. **Shared structure** — Common fields with varying data
-4. **Independent evolution** — Each type evolves separately
+1. **TaggedChoice** - Type discriminator for polymorphic data
+2. **Type-specific fixes** - Different migrations per entity type
+3. **Shared structure** - Common fields with varying data
+4. **Independent evolution** - Each type evolves separately
 
 ## Related
 

--- a/docs/examples/game-data-example/index.md
+++ b/docs/examples/game-data-example/index.md
@@ -60,11 +60,11 @@ This example shows how to migrate game player data:
 
 This example consists of:
 
-1. **[TypeReferences](type-references.md)** — Centralized type identifiers
-2. **[Schemas](schemas.md)** — Version-specific type definitions
-3. **[Fixes](fixes.md)** — Migration logic
-4. **[Bootstrap](bootstrap.md)** — Wiring it all together
-5. **[Complete Example](complete-example.md)** — Full working code
+1. **[TypeReferences](type-references.md)** - Centralized type identifiers
+2. **[Schemas](schemas.md)** - Version-specific type definitions
+3. **[Fixes](fixes.md)** - Migration logic
+4. **[Bootstrap](bootstrap.md)** - Wiring it all together
+5. **[Complete Example](complete-example.md)** - Full working code
 
 ## Quick Start
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -8,11 +8,11 @@ Practical examples demonstrating Aether Datafixers in real-world scenarios.
 
 A comprehensive example showing player data migration across multiple versions:
 
-- [TypeReferences Pattern](game-data-example/type-references.md) — Centralized type identifiers
-- [Schema Classes](game-data-example/schemas.md) — Version-specific type definitions
-- [DataFix Implementations](game-data-example/fixes.md) — Migration logic
-- [Bootstrap Creation](game-data-example/bootstrap.md) — Wiring it all together
-- [Complete Example](game-data-example/complete-example.md) — Full working code
+- [TypeReferences Pattern](game-data-example/type-references.md) - Centralized type identifiers
+- [Schema Classes](game-data-example/schemas.md) - Version-specific type definitions
+- [DataFix Implementations](game-data-example/fixes.md) - Migration logic
+- [Bootstrap Creation](game-data-example/bootstrap.md) - Wiring it all together
+- [Complete Example](game-data-example/complete-example.md) - Full working code
 
 ### 👤 [User Profile Example](user-profile-example.md)
 

--- a/docs/examples/user-profile-example.md
+++ b/docs/examples/user-profile-example.md
@@ -330,10 +330,10 @@ Migrated to V3:
 
 ## Key Patterns Demonstrated
 
-1. **Optional nested objects** — Address may not exist
-2. **Field splitting** — fullName → firstName + lastName
-3. **Default values** — Preferences added with defaults
-4. **Chained migrations** — v1 → v2 → v3 automatic chain
+1. **Optional nested objects** - Address may not exist
+2. **Field splitting** - fullName → firstName + lastName
+3. **Default values** - Preferences added with defaults
+4. **Chained migrations** - v1 → v2 → v3 automatic chain
 
 ## Related
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -76,7 +76,7 @@ Ready to begin? Start with the [Installation Guide](installation.md).
 
 ## Additional Resources
 
-- [Concepts Overview](../concepts/index.md) — Deep dive into framework concepts
-- [Tutorials](../tutorials/index.md) — Step-by-step guides for common tasks
-- [Examples](../examples/index.md) — Complete working examples
-- [API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/) — Full API documentation
+- [Concepts Overview](../concepts/index.md) - Deep dive into framework concepts
+- [Tutorials](../tutorials/index.md) - Step-by-step guides for common tasks
+- [Examples](../examples/index.md) - Complete working examples
+- [API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/) - Full API documentation

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -256,7 +256,7 @@ This includes auto-configuration for:
 - Health indicators and Actuator endpoints
 - Micrometer metrics integration
 
-→ [Spring Boot Quick Start](../spring-boot/getting-started.md) — Get started with Spring Boot integration
+→ [Spring Boot Quick Start](../spring-boot/getting-started.md) - Get started with Spring Boot integration
 
 ---
 
@@ -264,7 +264,7 @@ This includes auto-configuration for:
 
 For command-line usage without writing Java code, see the dedicated CLI documentation:
 
-→ [CLI Installation](../cli/installation.md) — Build and run the CLI tool
+→ [CLI Installation](../cli/installation.md) - Build and run the CLI tool
 
 ---
 
@@ -279,7 +279,7 @@ For schema analysis, validation, and migration coverage checking:
 </dependency>
 ```
 
-→ [Schema Tools Overview](../schema-tools/index.md) — Learn about schema diffing, validation, and analysis
+→ [Schema Tools Overview](../schema-tools/index.md) - Learn about schema diffing, validation, and analysis
 
 ---
 
@@ -287,4 +287,4 @@ For schema analysis, validation, and migration coverage checking:
 
 Now that you have Aether Datafixers installed, proceed to:
 
-→ [Quick Start](quick-start.md) — Get a working example in 5 minutes
+→ [Quick Start](quick-start.md) - Get a working example in 5 minutes

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -162,9 +162,9 @@ After: {"name":"Steve","experience":1500}
 
 ## Key Points
 
-- **DataVersion** is just an integer — use any numbering scheme (e.g., 1, 2, 3 or 100, 200, 300)
+- **DataVersion** is just an integer - use any numbering scheme (e.g., 1, 2, 3 or 100, 200, 300)
 - **TypeReference** routes data to the correct fixes
-- **Dynamic** operations are immutable — they return new instances
+- **Dynamic** operations are immutable - they return new instances
 - **DataFix** defines the actual transformation logic
 
 ---
@@ -177,6 +177,6 @@ This was a minimal example. For production use, you'll want:
 - **SchemaDataFix** base class for rule-based transformations
 - **DSL** for declaring type structures
 
-→ [Your First Migration](your-first-migration.md) — Complete tutorial with schemas
+→ [Your First Migration](your-first-migration.md) - Complete tutorial with schemas
 
-→ [Concepts Overview](../concepts/index.md) — Understand the framework in depth
+→ [Concepts Overview](../concepts/index.md) - Understand the framework in depth

--- a/docs/getting-started/your-first-migration.md
+++ b/docs/getting-started/your-first-migration.md
@@ -6,7 +6,7 @@ This tutorial walks you through creating a complete data migration system with s
 
 You're building a game that saves player data. Over time, the data format evolves:
 
-**Version 1.0.0 (ID: 100)** — Initial release
+**Version 1.0.0 (ID: 100)** - Initial release
 ```json
 {
   "playerName": "Steve",
@@ -18,7 +18,7 @@ You're building a game that saves player data. Over time, the data format evolve
 }
 ```
 
-**Version 1.1.0 (ID: 110)** — Restructured
+**Version 1.1.0 (ID: 110)** - Restructured
 ```json
 {
   "name": "Steve",
@@ -412,7 +412,7 @@ Congratulations! You've built your first complete migration system.
 
 Continue learning:
 
-- [Schema System](../concepts/schema-system.md) — Deep dive into schemas
-- [DataFix System](../concepts/datafix-system.md) — Understanding fixes
-- [Rewrite Rules](../concepts/rewrite-rules.md) — Rule combinators
-- [Multi-Version Migration](../tutorials/multi-version-migration.md) — Chain multiple fixes
+- [Schema System](../concepts/schema-system.md) - Deep dive into schemas
+- [DataFix System](../concepts/datafix-system.md) - Understanding fixes
+- [Rewrite Rules](../concepts/rewrite-rules.md) - Rule combinators
+- [Multi-Version Migration](../tutorials/multi-version-migration.md) - Chain multiple fixes

--- a/docs/how-to/handle-optional-fields.md
+++ b/docs/how-to/handle-optional-fields.md
@@ -103,7 +103,7 @@ registerType(TypeReferences.PLAYER, DSL.and(
 ));
 ```
 
-No fix needed — old data with the field still works.
+No fix needed - old data with the field still works.
 
 ## Convert Optional to Required
 
@@ -194,10 +194,10 @@ return Rules.transform(TypeReferences.PLAYER, player -> {
 
 ## Best Practices
 
-1. **Always use orElse** — Never assume a field exists
-2. **Provide sensible defaults** — Defaults should be safe values
-3. **Document optionality** — Note which fields are optional in schemas
-4. **Test both cases** — Test with and without optional fields
+1. **Always use orElse** - Never assume a field exists
+2. **Provide sensible defaults** - Defaults should be safe values
+3. **Document optionality** - Note which fields are optional in schemas
+4. **Test both cases** - Test with and without optional fields
 
 ## Related
 

--- a/docs/how-to/integrate-with-gson.md
+++ b/docs/how-to/integrate-with-gson.md
@@ -293,9 +293,9 @@ String value = dynamic.get("nullableField")
 
 ## Best Practices
 
-1. **Use GsonOps.INSTANCE** — It's a singleton, no need to create new instances
+1. **Use GsonOps.INSTANCE** - It's a singleton, no need to create new instances
 
-2. **Wrap early** — Convert to Dynamic as soon as you parse JSON
+2. **Wrap early** - Convert to Dynamic as soon as you parse JSON
 
 3. **Use codecs** for typed deserialization after migration
 
@@ -304,7 +304,7 @@ String value = dynamic.get("nullableField")
    new GsonBuilder().setPrettyPrinting().create()
    ```
 
-5. **Handle JsonNull** — Check for null values when reading
+5. **Handle JsonNull** - Check for null values when reading
 
 ## Related
 

--- a/docs/how-to/log-migrations.md
+++ b/docs/how-to/log-migrations.md
@@ -278,7 +278,7 @@ public class StatisticsCollector {
    log.debug("Data: {}", () -> serializeForLogging(data));
    ```
 
-4. **Consider log volume** — migrations may process millions of records
+4. **Consider log volume** - migrations may process millions of records
 
 ## Related
 

--- a/docs/how-to/remove-field.md
+++ b/docs/how-to/remove-field.md
@@ -205,10 +205,10 @@ registerType(TypeReferences.PLAYER, DSL.and(
 
 ## Best Practices
 
-1. **Document removed fields** — Keep a record of what was removed and why
-2. **Consider archiving** — For important data, archive instead of delete
-3. **Test thoroughly** — Ensure removal doesn't break dependent data
-4. **Update all schemas** — Make sure new schema doesn't expect the field
+1. **Document removed fields** - Keep a record of what was removed and why
+2. **Consider archiving** - For important data, archive instead of delete
+3. **Test thoroughly** - Ensure removal doesn't break dependent data
+4. **Update all schemas** - Make sure new schema doesn't expect the field
 
 ## Related
 

--- a/docs/how-to/restructure-data.md
+++ b/docs/how-to/restructure-data.md
@@ -1,6 +1,6 @@
 # How to Restructure Data
 
-This guide shows how to change the structure of your data — nesting, flattening, merging, and splitting objects.
+This guide shows how to change the structure of your data - nesting, flattening, merging, and splitting objects.
 
 ## Nesting Flat Fields
 

--- a/docs/how-to/test-migrations.md
+++ b/docs/how-to/test-migrations.md
@@ -385,9 +385,9 @@ class FullMigrationTest {
 
 ## Related
 
-- [Testkit Overview](../testkit/index.md) — Complete testkit documentation
-- [Test Data Builders](../testkit/test-data-builders.md) — Creating test data
-- [Custom Assertions](../testkit/assertions.md) — Available assertions
-- [QuickFix Factories](../testkit/quick-fix.md) — Factory methods
+- [Testkit Overview](../testkit/index.md) - Complete testkit documentation
+- [Test Data Builders](../testkit/test-data-builders.md) - Creating test data
+- [Custom Assertions](../testkit/assertions.md) - Available assertions
+- [QuickFix Factories](../testkit/quick-fix.md) - Factory methods
 - [Debug Migrations](debug-migrations.md)
 - [DataFix System](../concepts/datafix-system.md)

--- a/docs/how-to/use-diagnostics.md
+++ b/docs/how-to/use-diagnostics.md
@@ -10,7 +10,7 @@ Migration Diagnostics provides structured reports about what happens during a mi
 - Individual rule applications
 - Before/after snapshots of data
 
-Diagnostics are **opt-in** — migrations without a `DiagnosticContext` have zero overhead.
+Diagnostics are **opt-in** - migrations without a `DiagnosticContext` have zero overhead.
 
 ## Basic Usage
 
@@ -265,7 +265,7 @@ public class MigrationService {
 
 ## Performance Considerations
 
-- **Without diagnostics**: Zero overhead — migrations run at full speed
+- **Without diagnostics**: Zero overhead - migrations run at full speed
 - **With minimal options**: Small overhead for timing measurement
 - **With snapshots**: Additional overhead for serialization (use for debugging only)
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -10,15 +10,15 @@ This section contains guides for upgrading between major versions of Aether Data
 
 ## Before You Migrate
 
-1. **Back up your project** — Create a commit or backup before starting
-2. **Read the full guide** — Understand all changes before making modifications
-3. **Update dependencies first** — Ensure your build file references the new version
-4. **Run tests after** — Verify your migrations still work correctly
+1. **Back up your project** - Create a commit or backup before starting
+2. **Read the full guide** - Understand all changes before making modifications
+3. **Update dependencies first** - Ensure your build file references the new version
+4. **Run tests after** - Verify your migrations still work correctly
 
 ## General Migration Strategy
 
 1. Update the version in your build file (`pom.xml` or `build.gradle`)
-2. Attempt to compile — note all compilation errors
+2. Attempt to compile - note all compilation errors
 3. Apply automated migration patterns from the guide
 4. Fix any remaining issues manually
 5. Run your test suite

--- a/docs/migration/v0.5-to-v1.0.md
+++ b/docs/migration/v0.5-to-v1.0.md
@@ -83,7 +83,7 @@ Dynamic<JsonNode> testData = TestData.jacksonJson()
 
 ### 4. `Fixes.fixTypeEverywhere()` Signature Change
 
-The `Fixes.fixTypeEverywhere()` method now requires a `DynamicOps` parameter. In v0.5.x, this method was a **silent no-op** — it accepted a `Function<Dynamic<?>, Dynamic<?>>` but never applied it, returning the input unchanged. The fix adds the missing `DynamicOps` parameter needed to encode/decode the data during transformation.
+The `Fixes.fixTypeEverywhere()` method now requires a `DynamicOps` parameter. In v0.5.x, this method was a **silent no-op** - it accepted a `Function<Dynamic<?>, Dynamic<?>>` but never applied it, returning the input unchanged. The fix adds the missing `DynamicOps` parameter needed to encode/decode the data during transformation.
 
 **Before (v0.5.x):**
 ```java
@@ -104,7 +104,7 @@ TypeRewriteRule rule = Fixes.fixTypeEverywhere(
 );
 ```
 
-**Rationale:** The previous implementation could not function without `DynamicOps` — it silently returned input unchanged, which is a data corruption risk. Adding the parameter fixes the method to actually apply the transformation.
+**Rationale:** The previous implementation could not function without `DynamicOps` - it silently returned input unchanged, which is a data corruption risk. Adding the parameter fixes the method to actually apply the transformation.
 
 ---
 
@@ -115,11 +115,11 @@ TypeRewriteRule rule = Fixes.fixTypeEverywhere(
 The single-argument overloads of traversal methods are deprecated but **not removed**. Your code will still compile and run, but you'll see deprecation warnings.
 
 **Deprecated Methods:**
-- `Rules.all(rule)` — use `Rules.all(ops, rule)`
-- `Rules.one(rule)` — use `Rules.one(ops, rule)`
-- `Rules.everywhere(rule)` — use `Rules.everywhere(ops, rule)`
-- `Rules.bottomUp(rule)` — use `Rules.bottomUp(ops, rule)`
-- `Rules.topDown(rule)` — use `Rules.topDown(ops, rule)`
+- `Rules.all(rule)` - use `Rules.all(ops, rule)`
+- `Rules.one(rule)` - use `Rules.one(ops, rule)`
+- `Rules.everywhere(rule)` - use `Rules.everywhere(ops, rule)`
+- `Rules.bottomUp(rule)` - use `Rules.bottomUp(ops, rule)`
+- `Rules.topDown(rule)` - use `Rules.topDown(ops, rule)`
 
 **Why migrate?** The deprecated methods are **no-ops** that don't actually traverse children. They exist only for API compatibility. To get proper child traversal behavior, you must provide a `DynamicOps` instance.
 

--- a/docs/operations/debugging-guide.md
+++ b/docs/operations/debugging-guide.md
@@ -496,7 +496,7 @@ report.fixExecutions().stream()
 
 ## Related
 
-- [Error Scenarios](error-scenarios.md) — Exception handling reference
-- [How to Use Diagnostics](../how-to/use-diagnostics.md) — Full API reference
-- [How to Debug Migrations](../how-to/debug-migrations.md) — Basic debugging tips
-- [Monitoring & Alerting](monitoring-alerting.md) — Production monitoring
+- [Error Scenarios](error-scenarios.md) - Exception handling reference
+- [How to Use Diagnostics](../how-to/use-diagnostics.md) - Full API reference
+- [How to Debug Migrations](../how-to/debug-migrations.md) - Basic debugging tips
+- [Monitoring & Alerting](monitoring-alerting.md) - Production monitoring

--- a/docs/operations/error-scenarios.md
+++ b/docs/operations/error-scenarios.md
@@ -37,11 +37,11 @@ fix=rename_player_name, version=100->200, type=player
 
 ### Common Causes
 
-1. **Invalid input data** — Data doesn't match expected schema
-2. **Missing required field** — Fix expects a field that doesn't exist
-3. **Type mismatch** — Expected string but found number
-4. **Rule application failure** — TypeRewriteRule failed to apply
-5. **Null pointer** — Fix logic encountered null unexpectedly
+1. **Invalid input data** - Data doesn't match expected schema
+2. **Missing required field** - Fix expects a field that doesn't exist
+3. **Type mismatch** - Expected string but found number
+4. **Rule application failure** - TypeRewriteRule failed to apply
+5. **Null pointer** - Fix logic encountered null unexpectedly
 
 ### Resolution Steps
 
@@ -120,17 +120,17 @@ type=player, path=inventory[0].item.name
 ### Path Notation
 
 The path uses dot notation with array indices:
-- `player.name` — Field `name` in object `player`
-- `inventory[0]` — First element of array `inventory`
-- `inventory[0].item.damage` — Nested field access
+- `player.name` - Field `name` in object `player`
+- `inventory[0]` - First element of array `inventory`
+- `inventory[0].item.damage` - Nested field access
 
 ### Common Causes
 
-1. **Missing required field** — Schema expects field that doesn't exist
-2. **Invalid field type** — Expected number, got string
-3. **Malformed data** — Corrupt or truncated input
-4. **Schema mismatch** — Data version doesn't match expected schema
-5. **Null value** — Non-nullable field is null
+1. **Missing required field** - Schema expects field that doesn't exist
+2. **Invalid field type** - Expected number, got string
+3. **Malformed data** - Corrupt or truncated input
+4. **Schema mismatch** - Data version doesn't match expected schema
+5. **Null value** - Non-nullable field is null
 
 ### Resolution Steps
 
@@ -198,10 +198,10 @@ type=player
 
 ### Common Causes
 
-1. **Null value** — Required field is null
-2. **Unsupported type** — Codec doesn't support the value type
-3. **Codec misconfiguration** — Encoder not properly set up
-4. **Circular reference** — Object graph contains cycles
+1. **Null value** - Required field is null
+2. **Unsupported type** - Codec doesn't support the value type
+3. **Codec misconfiguration** - Encoder not properly set up
+4. **Circular reference** - Object graph contains cycles
 
 ### Resolution Steps
 
@@ -263,10 +263,10 @@ type=custom_entity, version=150
 
 ### Common Causes
 
-1. **Type not registered** — Forgot to register type in bootstrap
-2. **Schema not registered** — Version not registered in SchemaRegistry
-3. **Version gap** — No schema exists for intermediate version
-4. **Typo in TypeReference** — Type ID doesn't match registration
+1. **Type not registered** - Forgot to register type in bootstrap
+2. **Schema not registered** - Version not registered in SchemaRegistry
+3. **Version gap** - No schema exists for intermediate version
+4. **Typo in TypeReference** - Type ID doesn't match registration
 
 ### Resolution Steps
 
@@ -453,7 +453,7 @@ try {
 
 ## Related
 
-- [Debugging Guide](debugging-guide.md) — Systematic debugging approach
-- [Recovery Procedures](recovery-procedures.md) — How to recover from failures
-- [Common Errors](../troubleshooting/common-errors.md) — Quick error reference
-- [How to Use Diagnostics](../how-to/use-diagnostics.md) — Diagnostic API reference
+- [Debugging Guide](debugging-guide.md) - Systematic debugging approach
+- [Recovery Procedures](recovery-procedures.md) - How to recover from failures
+- [Common Errors](../troubleshooting/common-errors.md) - Quick error reference
+- [How to Use Diagnostics](../how-to/use-diagnostics.md) - Diagnostic API reference

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -17,10 +17,10 @@ Operational guidance for running Aether Datafixers in production environments. T
 
 Exception handling reference for production troubleshooting:
 - Exception hierarchy and context fields
-- `FixException` — Migration logic failures
-- `DecodeException` — Deserialization failures
-- `EncodeException` — Serialization failures
-- `RegistryException` — Missing type or version
+- `FixException` - Migration logic failures
+- `DecodeException` - Deserialization failures
+- `EncodeException` - Serialization failures
+- `RegistryException` - Missing type or version
 - Schema mismatch detection and resolution
 
 ### [Debugging Guide](debugging-guide.md)
@@ -54,25 +54,25 @@ Handling failures and data recovery:
 
 ### Migration Completely Failed
 
-1. **Check metrics** — Look at `aether.datafixers.migrations.failure` counter
-2. **Extract context** — See [Error Scenarios](error-scenarios.md#extracting-exception-context)
-3. **Enable DEBUG** — Set log level for `de.splatgames.aether.datafixers`
-4. **Capture diagnostics** — Use `DiagnosticContext` on a sample record
-5. **Restore if needed** — See [Recovery Procedures](recovery-procedures.md)
+1. **Check metrics** - Look at `aether.datafixers.migrations.failure` counter
+2. **Extract context** - See [Error Scenarios](error-scenarios.md#extracting-exception-context)
+3. **Enable DEBUG** - Set log level for `de.splatgames.aether.datafixers`
+4. **Capture diagnostics** - Use `DiagnosticContext` on a sample record
+5. **Restore if needed** - See [Recovery Procedures](recovery-procedures.md)
 
 ### High Failure Rate Alert
 
-1. **Check error breakdown** — Query failures by `error_type` tag
-2. **Identify pattern** — Same exception? Same data version?
-3. **Isolate bad records** — Query for records at problematic version
-4. **Apply targeted fix** — Fix data or code, retry migration
+1. **Check error breakdown** - Query failures by `error_type` tag
+2. **Identify pattern** - Same exception? Same data version?
+3. **Isolate bad records** - Query for records at problematic version
+4. **Apply targeted fix** - Fix data or code, retry migration
 
 ### Slow Migration Alert
 
-1. **Check version span** — Large version jumps take longer
-2. **Profile fixes** — Use `MigrationReport.fixExecutions()` timing
-3. **Check data size** — Large objects slow down processing
-4. **Consider batching** — Process in smaller batches
+1. **Check version span** - Large version jumps take longer
+2. **Profile fixes** - Use `MigrationReport.fixExecutions()` timing
+3. **Check data size** - Large objects slow down processing
+4. **Consider batching** - Process in smaller batches
 
 ---
 
@@ -111,7 +111,7 @@ readinessProbe:
 
 | Metric                                      | Type         | Alert Threshold |
 |---------------------------------------------|--------------|-----------------|
-| `aether.datafixers.migrations.success`      | Counter      | —               |
+| `aether.datafixers.migrations.success`      | Counter      | -               |
 | `aether.datafixers.migrations.failure`      | Counter      | > 0 per minute  |
 | `aether.datafixers.migrations.duration`     | Timer        | p99 > 1s        |
 | `aether.datafixers.migrations.version.span` | Distribution | avg > 50        |
@@ -122,7 +122,7 @@ See [Monitoring & Alerting](monitoring-alerting.md) for complete metrics referen
 
 ## Related
 
-- [Troubleshooting](../troubleshooting/index.md) — Basic troubleshooting tips
-- [Spring Boot Metrics](../spring-boot/metrics.md) — Detailed metrics reference
-- [Spring Boot Actuator](../spring-boot/actuator.md) — Actuator integration
-- [How to Use Diagnostics](../how-to/use-diagnostics.md) — Diagnostic API reference
+- [Troubleshooting](../troubleshooting/index.md) - Basic troubleshooting tips
+- [Spring Boot Metrics](../spring-boot/metrics.md) - Detailed metrics reference
+- [Spring Boot Actuator](../spring-boot/actuator.md) - Actuator integration
+- [How to Use Diagnostics](../how-to/use-diagnostics.md) - Diagnostic API reference

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -6,7 +6,7 @@ Production monitoring setup for Aether Datafixers using Micrometer, Prometheus, 
 
 | Metric                                      | Type         | Tags                   | Alert Threshold | Description           |
 |---------------------------------------------|--------------|------------------------|-----------------|-----------------------|
-| `aether.datafixers.migrations.success`      | Counter      | `domain`               | —               | Successful migrations |
+| `aether.datafixers.migrations.success`      | Counter      | `domain`               | -               | Successful migrations |
 | `aether.datafixers.migrations.failure`      | Counter      | `domain`, `error_type` | > 0/min         | Failed migrations     |
 | `aether.datafixers.migrations.duration`     | Timer        | `domain`               | p99 > 1s        | Execution time        |
 | `aether.datafixers.migrations.version.span` | Distribution | `domain`               | avg > 50        | Version distance      |
@@ -42,8 +42,8 @@ aether_datafixers_migrations_failure_total{domain="game",error_type="DecodeExcep
 ```
 
 **Tags:**
-- `domain` — DataFixer domain name
-- `error_type` — Exception class simple name
+- `domain` - DataFixer domain name
+- `error_type` - Exception class simple name
 
 ### Duration Timer
 
@@ -640,7 +640,7 @@ public class ExtendedMigrationMetrics extends MigrationMetrics {
 
 ## Related
 
-- [Spring Boot Metrics](../spring-boot/metrics.md) — Complete metrics reference
-- [Spring Boot Actuator](../spring-boot/actuator.md) — Actuator integration
-- [Debugging Guide](debugging-guide.md) — Diagnosing issues
-- [Recovery Procedures](recovery-procedures.md) — Responding to alerts
+- [Spring Boot Metrics](../spring-boot/metrics.md) - Complete metrics reference
+- [Spring Boot Actuator](../spring-boot/actuator.md) - Actuator integration
+- [Debugging Guide](debugging-guide.md) - Diagnosing issues
+- [Recovery Procedures](recovery-procedures.md) - Responding to alerts

--- a/docs/operations/recovery-procedures.md
+++ b/docs/operations/recovery-procedures.md
@@ -577,7 +577,7 @@ void verifyMigrationSuccess() {
 
 ## Related
 
-- [Error Scenarios](error-scenarios.md) — Exception handling reference
-- [Debugging Guide](debugging-guide.md) — Diagnosing issues
-- [Monitoring & Alerting](monitoring-alerting.md) — Detecting problems
-- [Troubleshooting](../troubleshooting/index.md) — Quick fixes
+- [Error Scenarios](error-scenarios.md) - Exception handling reference
+- [Debugging Guide](debugging-guide.md) - Diagnosing issues
+- [Monitoring & Alerting](monitoring-alerting.md) - Detecting problems
+- [Troubleshooting](../troubleshooting/index.md) - Quick fixes

--- a/docs/schema-tools/index.md
+++ b/docs/schema-tools/index.md
@@ -6,10 +6,10 @@ The **Aether Datafixers Schema Tools** module provides utilities for analyzing, 
 
 Schema Tools (`aether-datafixers-schema-tools`) is designed for:
 
-- **Schema Diffing** — Compare two schemas to see what types and fields changed
-- **Migration Analysis** — Analyze migration paths and verify fix coverage
-- **Validation** — Validate schema structure and enforce naming conventions
-- **Introspection** — Inspect type structures and extract field metadata
+- **Schema Diffing** - Compare two schemas to see what types and fields changed
+- **Migration Analysis** - Analyze migration paths and verify fix coverage
+- **Validation** - Validate schema structure and enforce naming conventions
+- **Introspection** - Inspect type structures and extract field metadata
 
 ## Quick Start
 
@@ -125,13 +125,13 @@ for (TypeDiff typeDiff : diff.typeDiffs().values()) {
 
 ## In This Section
 
-- [Schema Diffing](schema-diffing.md) — Compare schemas and detect changes
-- [Migration Analysis](migration-analysis.md) — Analyze migration paths and fix coverage
-- [Schema Validation](schema-validation.md) — Validate structure and conventions
-- [Type Introspection](type-introspection.md) — Inspect type structures
+- [Schema Diffing](schema-diffing.md) - Compare schemas and detect changes
+- [Migration Analysis](migration-analysis.md) - Analyze migration paths and fix coverage
+- [Schema Validation](schema-validation.md) - Validate structure and conventions
+- [Type Introspection](type-introspection.md) - Inspect type structures
 
 ---
 
 ## Next Steps
 
-→ [Schema Diffing](schema-diffing.md) — Learn how to compare schemas
+→ [Schema Diffing](schema-diffing.md) - Learn how to compare schemas

--- a/docs/schema-tools/migration-analysis.md
+++ b/docs/schema-tools/migration-analysis.md
@@ -6,9 +6,9 @@ The `schematools.analysis` package provides utilities for analyzing migration pa
 
 Migration analysis helps ensure your migrations are complete and well-structured:
 
-- **Path Analysis** — Understand the sequence of steps from one version to another
-- **Coverage Analysis** — Identify schema changes without corresponding DataFixes
-- **Gap Detection** — Find types or fields that might not be migrated correctly
+- **Path Analysis** - Understand the sequence of steps from one version to another
+- **Coverage Analysis** - Identify schema changes without corresponding DataFixes
+- **Gap Detection** - Find types or fields that might not be migrated correctly
 
 ## Core Components
 
@@ -73,7 +73,7 @@ if (coverage.isFullyCovered()) {
 
 ### From Bootstrap
 
-The most common approach — analyzes the bootstrap's schemas and fixes:
+The most common approach - analyzes the bootstrap's schemas and fixes:
 
 ```java
 MigrationAnalyzer analyzer = MigrationAnalyzer.forBootstrap(bootstrap);
@@ -386,15 +386,15 @@ public class MigrationSummary {
 
 ## Best Practices
 
-1. **Run coverage analysis in CI** — Catch missing fixes before release
-2. **Use field-level analysis for thorough checks** — Detect subtle field changes
-3. **Review orphan fixes** — They might indicate outdated code or schema mismatches
-4. **Generate migration summaries for releases** — Document what changes for users
+1. **Run coverage analysis in CI** - Catch missing fixes before release
+2. **Use field-level analysis for thorough checks** - Detect subtle field changes
+3. **Review orphan fixes** - They might indicate outdated code or schema mismatches
+4. **Generate migration summaries for releases** - Document what changes for users
 
 ---
 
 ## Related
 
-- [Schema Diffing](schema-diffing.md) — Understanding how diffs are computed
-- [Schema Validation](schema-validation.md) — Validating schema structure
-- [DataFix System](../concepts/datafix-system.md) — Core DataFix concepts
+- [Schema Diffing](schema-diffing.md) - Understanding how diffs are computed
+- [Schema Validation](schema-validation.md) - Validating schema structure
+- [DataFix System](../concepts/datafix-system.md) - Core DataFix concepts

--- a/docs/schema-tools/schema-diffing.md
+++ b/docs/schema-tools/schema-diffing.md
@@ -274,6 +274,6 @@ public class SchemaChangeReport {
 
 ## Related
 
-- [Type Introspection](type-introspection.md) — Understanding how types are analyzed
-- [Migration Analysis](migration-analysis.md) — Using diffs to analyze migration paths
-- [Schema System](../concepts/schema-system.md) — Core schema concepts
+- [Type Introspection](type-introspection.md) - Understanding how types are analyzed
+- [Migration Analysis](migration-analysis.md) - Using diffs to analyze migration paths
+- [Schema System](../concepts/schema-system.md) - Core schema concepts

--- a/docs/schema-tools/schema-validation.md
+++ b/docs/schema-tools/schema-validation.md
@@ -6,9 +6,9 @@ The `schematools.validation` package provides utilities for validating schema st
 
 Schema validation helps maintain quality and consistency:
 
-- **Structure Validation** — Detect cycles, version ordering issues, empty schemas
-- **Convention Checking** — Enforce naming patterns for types, fields, and classes
-- **Fix Coverage Validation** — Ensure all schema changes have corresponding fixes
+- **Structure Validation** - Detect cycles, version ordering issues, empty schemas
+- **Convention Checking** - Enforce naming patterns for types, fields, and classes
+- **Fix Coverage Validation** - Ensure all schema changes have corresponding fixes
 
 ## Core Components
 
@@ -427,16 +427,16 @@ class SchemaValidationTest {
 
 ## Best Practices
 
-1. **Run validation in CI** — Catch issues before they reach production
-2. **Start with RELAXED conventions** — Tighten rules gradually as the codebase matures
-3. **Use location context** — Helps identify exactly where issues occur
-4. **Treat coverage gaps as errors** — Missing migrations cause data loss
-5. **Document intentional deviations** — If you skip a convention, document why
+1. **Run validation in CI** - Catch issues before they reach production
+2. **Start with RELAXED conventions** - Tighten rules gradually as the codebase matures
+3. **Use location context** - Helps identify exactly where issues occur
+4. **Treat coverage gaps as errors** - Missing migrations cause data loss
+5. **Document intentional deviations** - If you skip a convention, document why
 
 ---
 
 ## Related
 
-- [Migration Analysis](migration-analysis.md) — Detailed coverage analysis
-- [Schema Diffing](schema-diffing.md) — Understanding schema changes
-- [Type Introspection](type-introspection.md) — How types are analyzed
+- [Migration Analysis](migration-analysis.md) - Detailed coverage analysis
+- [Schema Diffing](schema-diffing.md) - Understanding schema changes
+- [Type Introspection](type-introspection.md) - How types are analyzed

--- a/docs/schema-tools/type-introspection.md
+++ b/docs/schema-tools/type-introspection.md
@@ -6,10 +6,10 @@ The `schematools.introspection` package provides utilities for inspecting the in
 
 Type introspection enables:
 
-- **Structure Analysis** — Understand the shape of complex nested types
-- **Field Extraction** — Get metadata about all fields in a type
-- **Type Classification** — Categorize types (primitive, list, product, etc.)
-- **Comparison Support** — Create normalized structures for equality checking
+- **Structure Analysis** - Understand the shape of complex nested types
+- **Field Extraction** - Get metadata about all fields in a type
+- **Type Classification** - Categorize types (primitive, list, product, etc.)
+- **Comparison Support** - Create normalized structures for equality checking
 
 ## Core Components
 
@@ -374,16 +374,16 @@ public class DependencyAnalyzer {
 
 ## Performance Notes
 
-- **Introspection is recursive** — Complex nested types require more processing
-- **Results are immutable** — Safe to cache `TypeStructure` and `FieldInfo` instances
-- **Field extraction traverses all levels** — For large types, consider limiting depth
-- **Use `hasField()` for simple checks** — Faster than extracting all fields
+- **Introspection is recursive** - Complex nested types require more processing
+- **Results are immutable** - Safe to cache `TypeStructure` and `FieldInfo` instances
+- **Field extraction traverses all levels** - For large types, consider limiting depth
+- **Use `hasField()` for simple checks** - Faster than extracting all fields
 
 ---
 
 ## Related
 
-- [Schema Diffing](schema-diffing.md) — Uses introspection for field-level diffs
-- [Schema Validation](schema-validation.md) — Uses introspection for convention checking
-- [Type System](../concepts/type-system.md) — Core type concepts
-- [DSL](../concepts/dsl.md) — How types are defined
+- [Schema Diffing](schema-diffing.md) - Uses introspection for field-level diffs
+- [Schema Validation](schema-validation.md) - Uses introspection for convention checking
+- [Type System](../concepts/type-system.md) - Core type concepts
+- [DSL](../concepts/dsl.md) - How types are defined

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -4,13 +4,13 @@ This document provides general security best practices for processing untrusted 
 
 ## Defense in Depth
 
-Security should be implemented in layers. No single control is sufficient—combine multiple measures:
+Security should be implemented in layers. No single control is sufficient-combine multiple measures:
 
-1. **Input Validation** — Check size and format before parsing
-2. **Safe Parser Configuration** — Use security-hardened parser settings
-3. **Resource Limits** — Enforce depth, size, and time limits
-4. **Monitoring** — Log and alert on suspicious activity
-5. **Sandboxing** — Isolate high-risk processing
+1. **Input Validation** - Check size and format before parsing
+2. **Safe Parser Configuration** - Use security-hardened parser settings
+3. **Resource Limits** - Enforce depth, size, and time limits
+4. **Monitoring** - Log and alert on suspicious activity
+5. **Sandboxing** - Isolate high-risk processing
 
 ---
 

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -1,6 +1,6 @@
 # Security Overview
 
-This section provides guidance for securely handling untrusted data with Aether Datafixers. When processing data from external sources—user uploads, APIs, message queues, or file imports—proper security measures are essential to prevent attacks.
+This section provides guidance for securely handling untrusted data with Aether Datafixers. When processing data from external sources-user uploads, APIs, message queues, or file imports-proper security measures are essential to prevent attacks.
 
 ## Quick Reference
 
@@ -17,11 +17,11 @@ This section provides guidance for securely handling untrusted data with Aether 
 
 Apply the security recommendations in this documentation when:
 
-- **User Uploads** — Processing files uploaded by users (game saves, configs, data imports)
-- **External APIs** — Consuming data from third-party APIs
-- **Message Queues** — Processing messages from queues (Kafka, RabbitMQ, etc.)
-- **Database Blobs** — Migrating serialized data stored in databases
-- **File Imports** — Reading configuration or data files from untrusted sources
+- **User Uploads** - Processing files uploaded by users (game saves, configs, data imports)
+- **External APIs** - Consuming data from third-party APIs
+- **Message Queues** - Processing messages from queues (Kafka, RabbitMQ, etc.)
+- **Database Blobs** - Migrating serialized data stored in databases
+- **File Imports** - Reading configuration or data files from untrusted sources
 
 ## Documentation Structure
 
@@ -35,9 +35,9 @@ Understand the attack vectors and trust boundaries:
 ### [Format-Specific Security](format-considerations/index.md)
 
 Security considerations for each serialization format:
-- [SnakeYAML Security](format-considerations/snakeyaml.md) — **Critical: RCE prevention**
-- [Jackson Security](format-considerations/jackson.md) — XXE, polymorphic typing, depth limits
-- [Gson Security](format-considerations/gson.md) — Safe defaults and validation
+- [SnakeYAML Security](format-considerations/snakeyaml.md) - **Critical: RCE prevention**
+- [Jackson Security](format-considerations/jackson.md) - XXE, polymorphic typing, depth limits
+- [Gson Security](format-considerations/gson.md) - Safe defaults and validation
 
 ### [Best Practices](best-practices.md)
 

--- a/docs/security/spring-security-integration.md
+++ b/docs/security/spring-security-integration.md
@@ -6,10 +6,10 @@ This guide covers integrating secure Aether Datafixers usage with Spring Boot an
 
 When using the `aether-datafixers-spring-boot-starter`, additional security measures should be implemented at the Spring level:
 
-1. **Secure Bean Configuration** — Configure secure parsers as Spring beans
-2. **Request Validation** — Validate payloads before they reach migration endpoints
-3. **Rate Limiting** — Prevent abuse of migration endpoints
-4. **Audit Logging** — Track migration attempts for security monitoring
+1. **Secure Bean Configuration** - Configure secure parsers as Spring beans
+2. **Request Validation** - Validate payloads before they reach migration endpoints
+3. **Rate Limiting** - Prevent abuse of migration endpoints
+4. **Audit Logging** - Track migration attempts for security monitoring
 
 ---
 

--- a/docs/spring-boot/actuator.md
+++ b/docs/spring-boot/actuator.md
@@ -519,6 +519,6 @@ public class DataFixerEndpointExtension {
 
 ## Related Documentation
 
-- [Configuration Reference](configuration.md) — Actuator property settings
-- [Metrics Integration](metrics.md) — Micrometer metrics for dashboards
-- [Multi-Domain Setup](multi-domain.md) — Domain-specific health checks
+- [Configuration Reference](configuration.md) - Actuator property settings
+- [Metrics Integration](metrics.md) - Micrometer metrics for dashboards
+- [Multi-Domain Setup](multi-domain.md) - Domain-specific health checks

--- a/docs/spring-boot/configuration.md
+++ b/docs/spring-boot/configuration.md
@@ -14,8 +14,8 @@ All properties use the prefix `aether.datafixers`.
 | `default-format`          | enum    | `GSON`  | Default serialization format      |
 | `default-current-version` | Integer | `null`  | Fallback version for all domains  |
 | `domains.<name>.*`        | Map     | `{}`    | Per-domain configuration          |
-| `actuator.*`              | object  | —       | Actuator settings                 |
-| `metrics.*`               | object  | —       | Metrics settings                  |
+| `actuator.*`              | object  | -       | Actuator settings                 |
+| `metrics.*`               | object  | -       | Metrics settings                  |
 
 ---
 
@@ -54,8 +54,8 @@ aether:
 ```
 
 **Values**:
-- `GSON` — Use `GsonOps` for JSON serialization
-- `JACKSON` — Use `JacksonJsonOps` for JSON serialization
+- `GSON` - Use `GsonOps` for JSON serialization
+- `JACKSON` - Use `JacksonJsonOps` for JSON serialization
 
 **Note**: The corresponding library must be on the classpath. If only one is present, it is used automatically regardless of this setting.
 
@@ -401,7 +401,7 @@ public class DataFixerConfig {
 
 ## Related Documentation
 
-- [MigrationService API](migration-service.md) — Using the fluent migration API
-- [Multi-Domain Setup](multi-domain.md) — Configuring multiple DataFixer domains
-- [Actuator Integration](actuator.md) — Health indicators and endpoints
-- [Metrics Integration](metrics.md) — Micrometer metrics reference
+- [MigrationService API](migration-service.md) - Using the fluent migration API
+- [Multi-Domain Setup](multi-domain.md) - Configuring multiple DataFixer domains
+- [Actuator Integration](actuator.md) - Health indicators and endpoints
+- [Metrics Integration](metrics.md) - Micrometer metrics reference

--- a/docs/spring-boot/getting-started.md
+++ b/docs/spring-boot/getting-started.md
@@ -391,11 +391,11 @@ Response includes:
 
 ## What's Next?
 
-- [Configuration Reference](configuration.md) — Learn all available configuration options
-- [MigrationService API](migration-service.md) — Deep dive into the fluent migration API
-- [Multi-Domain Setup](multi-domain.md) — Configure multiple independent DataFixers
-- [Actuator Integration](actuator.md) — Health checks, endpoints, and monitoring
-- [Metrics Integration](metrics.md) — Track migration performance with Micrometer
+- [Configuration Reference](configuration.md) - Learn all available configuration options
+- [MigrationService API](migration-service.md) - Deep dive into the fluent migration API
+- [Multi-Domain Setup](multi-domain.md) - Configure multiple independent DataFixers
+- [Actuator Integration](actuator.md) - Health checks, endpoints, and monitoring
+- [Metrics Integration](metrics.md) - Track migration performance with Micrometer
 
 ---
 

--- a/docs/spring-boot/index.md
+++ b/docs/spring-boot/index.md
@@ -83,21 +83,21 @@ public class GameDataService {
 
 ### Getting Started
 
-- [Quick Start Guide](getting-started.md) — Add the starter to your project and run your first migration
+- [Quick Start Guide](getting-started.md) - Add the starter to your project and run your first migration
 
 ### Configuration
 
-- [Configuration Reference](configuration.md) — Complete reference for all `aether.datafixers.*` properties
+- [Configuration Reference](configuration.md) - Complete reference for all `aether.datafixers.*` properties
 
 ### Core Features
 
-- [MigrationService API](migration-service.md) — Fluent API for executing migrations
-- [Multi-Domain Setup](multi-domain.md) — Managing multiple independent DataFixer instances
+- [MigrationService API](migration-service.md) - Fluent API for executing migrations
+- [Multi-Domain Setup](multi-domain.md) - Managing multiple independent DataFixer instances
 
 ### Observability
 
-- [Actuator Integration](actuator.md) — Health indicators, info contributors, and custom endpoints
-- [Metrics Integration](metrics.md) — Micrometer metrics for migration observability
+- [Actuator Integration](actuator.md) - Health indicators, info contributors, and custom endpoints
+- [Metrics Integration](metrics.md) - Micrometer metrics for migration observability
 
 ---
 

--- a/docs/spring-boot/metrics.md
+++ b/docs/spring-boot/metrics.md
@@ -493,6 +493,6 @@ public class ExtendedMigrationMetrics extends MigrationMetrics {
 
 ## Related Documentation
 
-- [Configuration Reference](configuration.md) — Metrics property settings
-- [Actuator Integration](actuator.md) — Health checks and endpoints
-- [MigrationService API](migration-service.md) — Automatic metrics recording
+- [Configuration Reference](configuration.md) - Metrics property settings
+- [Actuator Integration](actuator.md) - Health checks and endpoints
+- [MigrationService API](migration-service.md) - Automatic metrics recording

--- a/docs/spring-boot/migration-service.md
+++ b/docs/spring-boot/migration-service.md
@@ -438,7 +438,7 @@ public class MigrationConfig {
 
 - `MigrationService` is **thread-safe** and can be shared across threads
 - Each `migrate()` call returns a new builder instance
-- `MigrationRequestBuilder` is **NOT thread-safe** — use separate instances per thread
+- `MigrationRequestBuilder` is **NOT thread-safe** - use separate instances per thread
 - `MigrationResult` is **immutable** and thread-safe
 
 ```java
@@ -473,12 +473,12 @@ When `MigrationMetrics` is available, the service automatically records:
 - **Duration timer**: Records migration duration
 - **Version span**: Records the number of versions migrated
 
-No additional code is needed — metrics are recorded transparently.
+No additional code is needed - metrics are recorded transparently.
 
 ---
 
 ## Related Documentation
 
-- [Configuration Reference](configuration.md) — Configure service behavior
-- [Multi-Domain Setup](multi-domain.md) — Working with multiple domains
-- [Metrics Integration](metrics.md) — Detailed metrics reference
+- [Configuration Reference](configuration.md) - Configure service behavior
+- [Multi-Domain Setup](multi-domain.md) - Working with multiple domains
+- [Metrics Integration](metrics.md) - Detailed metrics reference

--- a/docs/spring-boot/multi-domain.md
+++ b/docs/spring-boot/multi-domain.md
@@ -8,10 +8,10 @@ Multi-domain setups allow you to manage multiple independent DataFixer instances
 
 Use multi-domain setups when:
 
-- **Different data types evolve independently** — Game saves, user profiles, and configuration files may change at different rates
-- **Isolated version histories** — You want clear separation between migration paths
-- **Different migration strategies** — Some data types may require different approaches
-- **Modular architecture** — Different teams manage different data types
+- **Different data types evolve independently** - Game saves, user profiles, and configuration files may change at different rates
+- **Isolated version histories** - You want clear separation between migration paths
+- **Different migration strategies** - Some data types may require different approaches
+- **Modular architecture** - Different teams manage different data types
 
 ---
 
@@ -512,7 +512,7 @@ public final class UserTypeReferences {
 
 ### 4. Use MigrationService Over Direct Injection
 
-Prefer `MigrationService` for migrations — it provides metrics, error handling, and async support:
+Prefer `MigrationService` for migrations - it provides metrics, error handling, and async support:
 
 ```java
 // Preferred
@@ -607,7 +607,7 @@ public class DataMigrationFacade {
 
 ## Related Documentation
 
-- [Configuration Reference](configuration.md) — Per-domain property settings
-- [MigrationService API](migration-service.md) — Using `usingDomain()` method
-- [Actuator Integration](actuator.md) — Domain-specific health and endpoints
-- [Metrics Integration](metrics.md) — Domain-tagged metrics
+- [Configuration Reference](configuration.md) - Per-domain property settings
+- [MigrationService API](migration-service.md) - Using `usingDomain()` method
+- [Actuator Integration](actuator.md) - Domain-specific health and endpoints
+- [Metrics Integration](metrics.md) - Domain-tagged metrics

--- a/docs/testkit/index.md
+++ b/docs/testkit/index.md
@@ -15,7 +15,7 @@ Writing tests for data migrations shouldn't require extensive boilerplate. The t
 
 | Package             | Description                                                               |
 |---------------------|---------------------------------------------------------------------------|
-| `testkit`           | `TestData`, `TestDataBuilder`, `TestDataListBuilder` — Test data creation |
+| `testkit`           | `TestData`, `TestDataBuilder`, `TestDataListBuilder` - Test data creation |
 | `testkit.assertion` | `AetherAssertions`, `DynamicAssert`, `DataResultAssert`, `TypedAssert`    |
 | `testkit.harness`   | `DataFixTester`, `MigrationTester`, `SchemaTester`                        |
 | `testkit.factory`   | `QuickFix`, `MockSchemas`                                                 |
@@ -118,11 +118,11 @@ DataFix<JsonElement> transform = QuickFix.transformField(
 
 ## Guides
 
-- [Test Data Builders](test-data-builders.md) — Creating test data without boilerplate
-- [Custom Assertions](assertions.md) — AssertJ assertions for Dynamic, DataResult, Typed
-- [DataFixTester](datafix-tester.md) — Test harness for isolated DataFix testing
-- [QuickFix Factories](quick-fix.md) — Factory methods for common fix patterns
-- [Mock Schemas](mock-schemas.md) — Mock schema utilities for testing
+- [Test Data Builders](test-data-builders.md) - Creating test data without boilerplate
+- [Custom Assertions](assertions.md) - AssertJ assertions for Dynamic, DataResult, Typed
+- [DataFixTester](datafix-tester.md) - Test harness for isolated DataFix testing
+- [QuickFix Factories](quick-fix.md) - Factory methods for common fix patterns
+- [Mock Schemas](mock-schemas.md) - Mock schema utilities for testing
 
 ## Example: Complete DataFix Test
 
@@ -211,6 +211,6 @@ class PlayerFixTest {
 
 ## Related
 
-- [How to Test Migrations](../how-to/test-migrations.md) — Task-oriented testing guide
-- [DataFix System](../concepts/datafix-system.md) — Understanding DataFix
-- [Dynamic System](../concepts/dynamic-system.md) — Understanding Dynamic
+- [How to Test Migrations](../how-to/test-migrations.md) - Task-oriented testing guide
+- [DataFix System](../concepts/datafix-system.md) - Understanding DataFix
+- [Dynamic System](../concepts/dynamic-system.md) - Understanding Dynamic

--- a/docs/testkit/mock-schemas.md
+++ b/docs/testkit/mock-schemas.md
@@ -256,10 +256,10 @@ SchemaTester.forSchema(schema)
 
 ## Best Practices
 
-1. **Use minimal schemas for simple tests** — When you don't need registered types
-2. **Use the builder for complex scenarios** — When types are needed
-3. **Chain schemas for migration tests** — Set up proper parent relationships
-4. **Validate with SchemaTester** — Ensure schema configuration is correct
+1. **Use minimal schemas for simple tests** - When you don't need registered types
+2. **Use the builder for complex scenarios** - When types are needed
+3. **Chain schemas for migration tests** - Set up proper parent relationships
+4. **Validate with SchemaTester** - Ensure schema configuration is correct
 
 ## Related
 

--- a/docs/testkit/quick-fix.md
+++ b/docs/testkit/quick-fix.md
@@ -349,10 +349,10 @@ DataFix<JsonElement> fix = QuickFix.simple(
 
 ## Best Practices
 
-1. **Use descriptive fix names** — Names appear in error messages and logs
-2. **Keep fixes focused** — One fix should do one thing
-3. **Use compose() sparingly** — Prefer individual fixes for clarity in tests
-4. **Match production patterns** — Use QuickFix patterns that mirror your production code
+1. **Use descriptive fix names** - Names appear in error messages and logs
+2. **Keep fixes focused** - One fix should do one thing
+3. **Use compose() sparingly** - Prefer individual fixes for clarity in tests
+4. **Match production patterns** - Use QuickFix patterns that mirror your production code
 
 ## Related
 

--- a/docs/testkit/test-data-builders.md
+++ b/docs/testkit/test-data-builders.md
@@ -319,10 +319,10 @@ void testPlayerMigration() {
 
 ## Best Practices
 
-1. **Use descriptive variable names** — `oldPlayer`, `expectedResult` rather than `data1`, `data2`
-2. **Group related fields** — Use `putObject()` for logical groupings
-3. **Reuse common structures** — Extract common test data to helper methods
-4. **Match production structure** — Keep test data structure close to real data
+1. **Use descriptive variable names** - `oldPlayer`, `expectedResult` rather than `data1`, `data2`
+2. **Group related fields** - Use `putObject()` for logical groupings
+3. **Reuse common structures** - Extract common test data to helper methods
+4. **Match production structure** - Keep test data structure close to real data
 
 ## Related
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -4,9 +4,9 @@ Solutions to common issues with Aether Datafixers.
 
 ## Quick Links
 
-- [Common Errors](common-errors.md) — Error messages and solutions
-- [Debugging Tips](debugging-tips.md) — Strategies for finding issues
-- [FAQ](faq.md) — Frequently asked questions
+- [Common Errors](common-errors.md) - Error messages and solutions
+- [Debugging Tips](debugging-tips.md) - Strategies for finding issues
+- [FAQ](faq.md) - Frequently asked questions
 
 ## Operations Runbook
 

--- a/docs/tutorials/basic-migration.md
+++ b/docs/tutorials/basic-migration.md
@@ -389,7 +389,7 @@ class PlayerMigrationTest {
 
 ## Next Steps
 
-- **[Multi-Version Migration](multi-version-migration.md)** — Chain multiple fixes
-- **[Schema Inheritance](schema-inheritance.md)** — Organize large projects
-- **[How-To: Rename Field](../how-to/rename-field.md)** — More rename patterns
+- **[Multi-Version Migration](multi-version-migration.md)** - Chain multiple fixes
+- **[Schema Inheritance](schema-inheritance.md)** - Organize large projects
+- **[How-To: Rename Field](../how-to/rename-field.md)** - More rename patterns
 

--- a/docs/tutorials/custom-dynamicops.md
+++ b/docs/tutorials/custom-dynamicops.md
@@ -582,8 +582,8 @@ public static final SimpleMapOps INSTANCE = new SimpleMapOps();
 
 ## Next Steps
 
-- **[API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/)** — Full interface
-- **[Dynamic System](../concepts/dynamic-system.md)** — How it all fits together
+- **[API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/)** - Full interface
+- **[Dynamic System](../concepts/dynamic-system.md)** - How it all fits together
 
 ## Built-in Implementations
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -33,37 +33,37 @@ This section contains step-by-step tutorials that guide you through common tasks
 
 If you're new to data migration, follow this path:
 
-1. **[Basic Migration](basic-migration.md)** — Learn the fundamentals
-2. **[Multi-Version Migration](multi-version-migration.md)** — Handle version chains
-3. **[Schema Inheritance](schema-inheritance.md)** — Organize your schemas
+1. **[Basic Migration](basic-migration.md)** - Learn the fundamentals
+2. **[Multi-Version Migration](multi-version-migration.md)** - Handle version chains
+3. **[Schema Inheritance](schema-inheritance.md)** - Organize your schemas
 
 ### For JSON/Data Processing
 
 If you're focused on data processing:
 
-1. **[Using Codecs](using-codecs.md)** — Encode and decode data
-2. **[RecordCodecBuilder](record-codec-builder.md)** — Build complex codecs
-3. **[Custom DynamicOps](custom-dynamicops.md)** — Add format support
+1. **[Using Codecs](using-codecs.md)** - Encode and decode data
+2. **[RecordCodecBuilder](record-codec-builder.md)** - Build complex codecs
+3. **[Custom DynamicOps](custom-dynamicops.md)** - Add format support
 
 ### For Complex Migrations
 
 If you need advanced migration patterns:
 
-1. **[Schema Inheritance](schema-inheritance.md)** — Efficient schema organization
-2. **[Polymorphic Data](polymorphic-data.md)** — Handle type variants
-3. **[Nested Transformations](nested-transformations.md)** — Deep restructuring
+1. **[Schema Inheritance](schema-inheritance.md)** - Efficient schema organization
+2. **[Polymorphic Data](polymorphic-data.md)** - Handle type variants
+3. **[Nested Transformations](nested-transformations.md)** - Deep restructuring
 
 ## Tutorial Format
 
 Each tutorial follows a consistent format:
 
-1. **Goal** — What you'll accomplish
-2. **Prerequisites** — What you need to know
-3. **Setup** — Project configuration
-4. **Step-by-Step Instructions** — Detailed walkthrough
-5. **Complete Code** — Full working example
-6. **Testing** — How to verify it works
-7. **Next Steps** — Where to go from here
+1. **Goal** - What you'll accomplish
+2. **Prerequisites** - What you need to know
+3. **Setup** - Project configuration
+4. **Step-by-Step Instructions** - Detailed walkthrough
+5. **Complete Code** - Full working example
+6. **Testing** - How to verify it works
+7. **Next Steps** - Where to go from here
 
 ## Quick Reference
 

--- a/docs/tutorials/multi-version-migration.md
+++ b/docs/tutorials/multi-version-migration.md
@@ -463,7 +463,7 @@ private Dynamic<?> maybeAddLevel(Dynamic<?> player) {
 
 ## Next Steps
 
-- **[Schema Inheritance](schema-inheritance.md)** — Efficient schema organization
-- **[Nested Transformations](nested-transformations.md)** — Complex restructuring
-- **[Testing Migrations](../how-to/test-migrations.md)** — Write robust tests
+- **[Schema Inheritance](schema-inheritance.md)** - Efficient schema organization
+- **[Nested Transformations](nested-transformations.md)** - Complex restructuring
+- **[Testing Migrations](../how-to/test-migrations.md)** - Write robust tests
 

--- a/docs/tutorials/nested-transformations.md
+++ b/docs/tutorials/nested-transformations.md
@@ -122,7 +122,7 @@ public class PlayerV2ToV3Fix extends SchemaDataFix {
 
 ## Pattern 2: Flattening Nested Objects
 
-Going the other direction — extracting nested fields to top level:
+Going the other direction - extracting nested fields to top level:
 
 ```java
 private Dynamic<?> flattenPosition(Dynamic<?> player) {
@@ -422,7 +422,7 @@ void testNestPosition() {
 
 ## Next Steps
 
-- **[Custom DynamicOps](custom-dynamicops.md)** — Support new formats
-- **[Rewrite Rules](../concepts/rewrite-rules.md)** — Rule combinators
-- **[How-To: Restructure Data](../how-to/restructure-data.md)** — More patterns
+- **[Custom DynamicOps](custom-dynamicops.md)** - Support new formats
+- **[Rewrite Rules](../concepts/rewrite-rules.md)** - Rule combinators
+- **[How-To: Restructure Data](../how-to/restructure-data.md)** - More patterns
 

--- a/docs/tutorials/polymorphic-data.md
+++ b/docs/tutorials/polymorphic-data.md
@@ -474,7 +474,7 @@ When removing an entity type:
 
 ## Next Steps
 
-- **[Nested Transformations](nested-transformations.md)** — Complex restructuring
-- **[DSL Reference](../concepts/dsl.md)** — TaggedChoice details
-- **[Prism Optic](../concepts/optics/prism.md)** — Sum type optics
+- **[Nested Transformations](nested-transformations.md)** - Complex restructuring
+- **[DSL Reference](../concepts/dsl.md)** - TaggedChoice details
+- **[Prism Optic](../concepts/optics/prism.md)** - Sum type optics
 

--- a/docs/tutorials/record-codec-builder.md
+++ b/docs/tutorials/record-codec-builder.md
@@ -95,11 +95,11 @@ RecordCodecBuilder.create(instance ->
 
 ### The Pattern Breakdown
 
-1. **`RecordCodecBuilder.create(instance -> ...)`** — Starts the builder
-2. **`instance.group(...)`** — Groups all field codecs
-3. **`Codecs.TYPE.fieldOf("key")`** — Creates a field codec for a JSON key
-4. **`.forGetter(Record::field)`** — Specifies how to get the value during encoding
-5. **`.apply(instance, Constructor::new)`** — Specifies how to construct during decoding
+1. **`RecordCodecBuilder.create(instance -> ...)`** - Starts the builder
+2. **`instance.group(...)`** - Groups all field codecs
+3. **`Codecs.TYPE.fieldOf("key")`** - Creates a field codec for a JSON key
+4. **`.forGetter(Record::field)`** - Specifies how to get the value during encoding
+5. **`.apply(instance, Constructor::new)`** - Specifies how to construct during decoding
 
 ## Multiple Fields (3+)
 
@@ -443,7 +443,7 @@ public static final Codec<Player> CODEC = ...;
 
 ## Next Steps
 
-- **[Polymorphic Data](polymorphic-data.md)** — Handle sum types
-- **[API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/)** — Full API
-- **[Using Codecs](using-codecs.md)** — Codec basics
+- **[Polymorphic Data](polymorphic-data.md)** - Handle sum types
+- **[API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/)** - Full API
+- **[Using Codecs](using-codecs.md)** - Codec basics
 

--- a/docs/tutorials/schema-inheritance.md
+++ b/docs/tutorials/schema-inheritance.md
@@ -436,7 +436,7 @@ Each schema should only contain changed types. If a schema is getting large, con
 
 ## Next Steps
 
-- **[Polymorphic Data](polymorphic-data.md)** — Handle sum types
-- **[Nested Transformations](nested-transformations.md)** — Complex restructuring
-- **[DSL Reference](../concepts/dsl.md)** — All type templates
+- **[Polymorphic Data](polymorphic-data.md)** - Handle sum types
+- **[Nested Transformations](nested-transformations.md)** - Complex restructuring
+- **[DSL Reference](../concepts/dsl.md)** - All type templates
 

--- a/docs/tutorials/using-codecs.md
+++ b/docs/tutorials/using-codecs.md
@@ -390,7 +390,7 @@ Invalid (-5): Optional[Must be positive]
 
 ## Next Steps
 
-- **[RecordCodecBuilder](record-codec-builder.md)** — Build codecs for complex records
-- **[API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/)** — Full API documentation
-- **[DataResult](../concepts/data-result.md)** — Error handling patterns
+- **[RecordCodecBuilder](record-codec-builder.md)** - Build codecs for complex records
+- **[API Reference](https://software.splatgames.de/docs/aether/aether-datafixers/)** - Full API documentation
+- **[DataResult](../concepts/data-result.md)** - Error handling patterns
 


### PR DESCRIPTION
## Summary
This PR standardizes hyphen usage across all documentation and fixes punctuation in Javadoc comments for optics and format classes to enhance consistency and readability.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Build / CI

## Related Issues
None.

## Changes
- Standardized hyphen usage throughout the documentation.
- Corrected punctuation in Javadoc comments in optics and format classes.

## Verification
- [x] Unit tests added/updated
- [x] Existing tests pass
- [x] Manual verification performed (if applicable)

## Breaking Changes
None.

## Checklist
- [x] Code follows project conventions
- [x] Public APIs are documented
- [ ] Tests cover new behavior
- [ ] No unnecessary dependencies added