### PR TITLE
fix(release): unblock 1.0.0-rc.1 javadoc generation

### DIFF
--- a/aether-datafixers-schema-tools/src/main/java/de/splatgames/aether/datafixers/schematools/validation/ConventionRules.java
+++ b/aether-datafixers-schema-tools/src/main/java/de/splatgames/aether/datafixers/schematools/validation/ConventionRules.java
@@ -412,18 +412,17 @@ public final class ConventionRules {
 
     /**
      * Builder for creating custom ConventionRules instances.
-     * <p>
-     * This builder allows you to configure various aspects of convention checking, such as:
-     *     <ul>
-     *         <li>Enabling/disabling convention checks</li>
-     *         <li>Setting regex patterns for type and field names</li>
-     *         <li>Requiring specific prefixes/suffixes for type, schema, and
-     *         fix class names</li>
-     *         <li>Choosing whether violations are treated as errors or warnings</li>
-     *         <li>Providing custom validation predicates for type and field names</li>
-     *   </ul>
-     *   This builder is used to create immutable ConventionRules instances that can be applied during schema validation.
-     * </p>
+     *
+     * <p>This builder allows you to configure various aspects of convention checking, such as:</p>
+     * <ul>
+     *     <li>Enabling/disabling convention checks</li>
+     *     <li>Setting regex patterns for type and field names</li>
+     *     <li>Requiring specific prefixes/suffixes for type, schema, and fix class names</li>
+     *     <li>Choosing whether violations are treated as errors or warnings</li>
+     *     <li>Providing custom validation predicates for type and field names</li>
+     * </ul>
+     *
+     * <p>This builder is used to create immutable ConventionRules instances that can be applied during schema validation.</p>
      *
      * @see ConventionRules
      */

--- a/aether-datafixers-testkit/src/main/java/de/splatgames/aether/datafixers/testkit/TestDataBuilder.java
+++ b/aether-datafixers-testkit/src/main/java/de/splatgames/aether/datafixers/testkit/TestDataBuilder.java
@@ -90,13 +90,11 @@ public final class TestDataBuilder<T> {
 
     /**
      * Internal state:
-     * <p>
-     *     <ul>
-     *         <li>{@code ops}: The DynamicOps used for creating values.</li>
-     *         <li>{@code fields}: A map of field names to their Dynamic values.</li>
-     *         <li>{@code isObjectMode}: A flag to ensure object() is called before adding fields.</li>
-     *     </ul>
-     * </p>
+     * <ul>
+     *     <li>{@code ops}: The DynamicOps used for creating values.</li>
+     *     <li>{@code fields}: A map of field names to their Dynamic values.</li>
+     *     <li>{@code isObjectMode}: A flag to ensure object() is called before adding fields.</li>
+     * </ul>
      */
     private final DynamicOps<T> ops;
     /**

--- a/aether-datafixers-testkit/src/main/java/de/splatgames/aether/datafixers/testkit/context/AssertingContext.java
+++ b/aether-datafixers-testkit/src/main/java/de/splatgames/aether/datafixers/testkit/context/AssertingContext.java
@@ -69,15 +69,13 @@ public final class AssertingContext implements DataFixerContext {
 
     /**
      * Defines the behavior of the AssertingContext when a warning is logged.
-     * <p>
-     *  <ul>
+     * <ul>
      *     <li><strong>FAIL_ON_WARN</strong>: Throws an AssertionError immediately on any warn() call.</li>
      *     <li><strong>COLLECT</strong>: Collects warning messages for later
      *     assertion via warnings(), warningCount(), hasWarnings(), and assertNoWarnings().</li>
      *     <li><strong>SILENT</strong>: Ignores all warn()
      *     calls without throwing or collecting (useful when warnings are expected).</li>
-     *  </ul>
-     * </p>
+     * </ul>
      */
     private final Mode mode;
     /**


### PR DESCRIPTION
## Summary

Re-opens the 1.0.0-rc.1 release window. The original tag-push of \`v1.0.0-rc.1\` after #283 failed in \`release.yml\` during \`mvn deploy -Prelease\` because \`maven-javadoc-plugin\` 3.12.0 rejected an orphan \`</p>\` after a \`</ul>\` in \`ConventionRules.Builder\`'s Javadoc.

The failed tag has been deleted from the remote — Maven Central was never reached and no GitHub Release was created, so the rollback is purely local to the tag namespace.

## Fix

Removes the orphan \`</p>\` anti-pattern in three places:

| File                                                                                                          | Member                          | Visibility | Blocker? |
|---------------------------------------------------------------------------------------------------------------|---------------------------------|------------|----------|
| \`aether-datafixers-schema-tools/.../validation/ConventionRules.java\`                                        | \`Builder\` inner class         | public     | yes      |
| \`aether-datafixers-testkit/.../testkit/TestDataBuilder.java\`                                                | \`ops\` field                   | private    | no       |
| \`aether-datafixers-testkit/.../testkit/context/AssertingContext.java\`                                       | \`mode\` field                  | private    | no       |

The valid \`<p>...</p>\` prose block in \`AssertingContext#formatMessage\` is intentionally left untouched.

## Verification

- [x] \`mvn -B -DskipTests javadoc:jar\` on \`-pl aether-datafixers-schema-tools,aether-datafixers-testkit -am\` — BUILD SUCCESS
- [x] No other \`^\s*\*\s*</p>\s*\$\` matches remain in the tree (apart from the one legitimate prose block)

## Re-tag plan

After merge: re-tag \`v1.0.0-rc.1\` on the new \`main\` HEAD. The release workflow will rerun and (this time) reach the Maven Central deploy step.

## Test plan

- [ ] CI green on \`release/1.0.0-rc\`
- [ ] After merge, re-tag \`v1.0.0-rc.1\` on main HEAD
- [ ] \`release.yml\` reaches Deploy to Maven Central + Create GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)