### PR TITLE
build: restore 1.0.0-SNAPSHOT on develop after 1.0.0-rc.1

### DIFF
--- a/aether-datafixers-api/pom.xml
+++ b/aether-datafixers-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-api</artifactId>

--- a/aether-datafixers-benchmarks/pom.xml
+++ b/aether-datafixers-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-benchmarks</artifactId>

--- a/aether-datafixers-bom/pom.xml
+++ b/aether-datafixers-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-bom</artifactId>

--- a/aether-datafixers-cli/pom.xml
+++ b/aether-datafixers-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-cli</artifactId>

--- a/aether-datafixers-codec/pom.xml
+++ b/aether-datafixers-codec/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-codec</artifactId>

--- a/aether-datafixers-core/pom.xml
+++ b/aether-datafixers-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-core</artifactId>

--- a/aether-datafixers-examples/pom.xml
+++ b/aether-datafixers-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-examples</artifactId>

--- a/aether-datafixers-functional-tests/pom.xml
+++ b/aether-datafixers-functional-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-functional-tests</artifactId>

--- a/aether-datafixers-schema-tools/pom.xml
+++ b/aether-datafixers-schema-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-schema-tools</artifactId>

--- a/aether-datafixers-spring-boot-starter/pom.xml
+++ b/aether-datafixers-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-spring-boot-starter</artifactId>

--- a/aether-datafixers-testkit/pom.xml
+++ b/aether-datafixers-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.splatgames.aether.datafixers</groupId>
         <artifactId>aether-datafixers</artifactId>
-        <version>1.0.0-rc.1</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aether-datafixers-testkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.splatgames.aether.datafixers</groupId>
     <artifactId>aether-datafixers</artifactId>
-    <version>1.0.0-rc.1</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>aether-datafixers-api</module>


### PR DESCRIPTION
## Summary

Final step of the 1.0.0-rc.1 release cycle. Reverts the parent POM and every module POM from \`1.0.0-rc.1\` back to **\`1.0.0-SNAPSHOT\`** so day-to-day development on \`develop\` continues against a SNAPSHOT version. The 1.0.0-rc.1 artifacts remain published to Maven Central via the [v1.0.0-rc.1](https://github.com/aether-framework/aether-datafixers/releases/tag/v1.0.0-rc.1) tag on \`main\`.

## Release cycle recap

| Step                                                                                                                | PR/Tag       | Status |
|---------------------------------------------------------------------------------------------------------------------|--------------|--------|
| 1. Docs prep (\`RELEASE.md\`, \`CHANGELOG.md\`, \`README.md\`) on \`feature/release-ready-for-1.0.0-rc.1-without-version-bump\` | #282         | ✅ merged |
| 2. Version bump 1.0.0-SNAPSHOT → 1.0.0-rc.1 on \`release/1.0.0-rc\`                                                  | #283         | ✅ merged |
| 3. Javadoc release-blocker fix on \`release/1.0.0-rc\`                                                               | #290         | ✅ merged |
| 4. Tag \`v1.0.0-rc.1\` → \`release.yml\` → Maven Central + GitHub Release                                            | v1.0.0-rc.1  | ✅ published |
| 5. Sync \`main\` → \`develop\` (brings release commits back)                                                         | #291         | ✅ merged |
| 6. **(this PR)** Restore 1.0.0-SNAPSHOT on develop                                                                  | this         | ⏳     |

## Test plan

- [ ] PR diff: only 12 POM version reverts (1.0.0-rc.1 → 1.0.0-SNAPSHOT), no other changes
- [ ] CI green on \`feature/1.0.0-after-rc-version-bump\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)